### PR TITLE
improve server response

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -120,7 +120,9 @@ server.start = function() {
       try {
         const context = generateContext({request, response, ...args});
         const result = await method.call(boundKlass, context);
-        response.json({result});
+        if (!(result instanceof http.ServerResponse)) {
+          response.json({result});
+        }
       } catch(error) {
         printError(error);
         response.status(500).json({});


### PR DESCRIPTION
A ideia do commit é permitir que o usuário consiga retornar um response em uma função do servidor. O principal problema surgiu em tratar os status code de uma response. Atualmente, se você tentar dar um **return response...**, ele funciona, mas dá esse erro interno:
```
Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
```
O problema é que ele chama o response duas vezes, pq chama o do retorno e o default. Teria uma alternativa que eu acho o código bem feio, pra tratar o erro e não dar nenhum problema interno, que seria da seguinte forma:
```js
    if (!post) {
      response.statusCode = 400;
      return { message: "Post não encontrado." };
    }
 ```
 
Com o pull request você permite os dois tipos de chamadas e resolve o erro interno em relação a esse tipo de chamada:
```js
    if (!post) {
      return response.status(400).json({ message: "Post não encontrado." });
    }
```
