### PR TITLE
Run in the specific port passed as argument

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "glob": "^7.1.7",
     "ignore-loader": "^0.1.2",
     "mini-css-extract-plugin": "^0.9.0",
+    "minimist": "^1.2.5",
     "node-fetch": "^2.6.0",
     "nodemon-webpack-plugin": "^4.3.1",
     "purgecss-webpack-plugin": "^2.2.0",

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -16,6 +16,7 @@ const environment = command === 'start' ? 'development' : 'production';
 const { input } = params;
 
 const compiler = webpack(config.map((env) => env(null, { environment, input })));
+process.env.PORT = require('minimist')(process.argv.slice(2)).port;
 
 let lastTrace = '';
 let compilingIndex = 1;


### PR DESCRIPTION
Related issue #91 "Add --port argument to npx nullstack start"