### PR TITLE
:sparkles: persistent instances

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -23,8 +23,8 @@ client.generateContext = generateContext;
 
 client.renderQueue = null;
 
-client.update = async function() {
-  if(client.initialized) {
+client.update = async function () {
+  if (client.initialized) {
     clearInterval(client.renderQueue);
     client.renderQueue = setTimeout(async () => {
       const scope = client;
@@ -43,32 +43,36 @@ client.update = async function() {
   }
 }
 
-client.processLifecycleQueues = async function() {
-  if(!client.initialized) {
+client.processLifecycleQueues = async function () {
+  if (!client.initialized) {
     client.initialized = true;
     client.hydrated = true;
   }
   const initiationQueue = client.initiationQueue;
   const hydrationQueue = client.hydrationQueue;
-  for(const instance of initiationQueue) {
+  for (const instance of initiationQueue) {
     instance.initiate && await instance.initiate();
     instance._self.initiated = true;
   }
-  if(initiationQueue.length) {
+  if (initiationQueue.length) {
     client.update();
   }
-  for(const instance of hydrationQueue) {
+  for (const instance of hydrationQueue) {
     instance.hydrate && await instance.hydrate();
     instance._self.hydrated = true;
   }
-  if(hydrationQueue.length) {
+  if (hydrationQueue.length) {
     client.update();
   }
-  for(const key in client.instances) {
+  for (const key in client.instances) {
     const instance = client.instances[key];
-    if(!client.renewalQueue.includes(instance)) {
+    if (!client.renewalQueue.includes(instance) && !instance._self.terminated) {
       instance.terminate && await instance.terminate();
-      delete client.instances[key];
+      if (instance._self.persistent) {
+        instance._self.terminated = true
+      } else {
+        delete client.instances[key];
+      }
     }
   }
   router._changed = false;

--- a/client/index.js
+++ b/client/index.js
@@ -8,7 +8,7 @@ import render from './render';
 import instanceProxyHandler from './instanceProxyHandler';
 import page from './page';
 import environment from './environment';
-import params, {updateParams} from './params';
+import params, { updateParams } from './params';
 import settings from './settings';
 import worker from './worker';
 import project from './project';
@@ -53,7 +53,7 @@ export default class Nullstack {
     client.currentInstance = null;
     client.initializer = () => element(Starter);
     client.selector = document.querySelector('#application');
-    if(environment.mode === 'spa') {
+    if (environment.mode === 'spa') {
       scope.plugins = loadPlugins(scope);
       context.environment = environment;
       client.virtualDom = await generateTree(client.initializer(), scope);
@@ -76,13 +76,14 @@ export default class Nullstack {
   _self = {
     prerendered: false,
     initiated: false,
-    hydrated: false
+    hydrated: false,
+    terminated: false,
   }
 
   constructor() {
     const methods = getProxyableMethods(this);
     const proxy = new Proxy(this, instanceProxyHandler);
-    for(const method of methods) {
+    for (const method of methods) {
       this[method] = this[method].bind(proxy);
     }
     return proxy;

--- a/client/windowEvent.js
+++ b/client/windowEvent.js
@@ -3,7 +3,7 @@ let timer = null;
 export default function windowEvent(name) {
   clearTimeout(timer);
   setTimeout(() => {
-    const event = new Event('nullstack.'+name);
+    const event = new Event('nullstack.' + name);
     window.dispatchEvent(event);
   }, 0);
 }

--- a/shared/generateTree.js
+++ b/shared/generateTree.js
@@ -12,7 +12,7 @@ async function generateBranch(parent, node, depth, scope) {
   }
 
   if (isClass(node)) {
-    const key = (node.attributes.key || generateKey(depth)) + (node.attributes.route ? scope.context.router.url : '')
+    const key = node.attributes.key ? node.attributes.key : generateKey(depth) + (node.attributes.route ? scope.context.router.url : '')
     if (
       scope.context.environment.client &&
       scope.context.router._changed &&
@@ -27,7 +27,7 @@ async function generateBranch(parent, node, depth, scope) {
         for (const segment in newSegments) {
           if (oldSegments[segment] !== newSegments[segment]) {
             delete scope.memory[key];
-            delete scope.instances[key];
+            // delete scope.instances[key];
           }
         }
       }

--- a/shared/generateTree.js
+++ b/shared/generateTree.js
@@ -1,57 +1,62 @@
 import generateKey from '../shared/generateKey';
-import {isClass, isFalse, isFunction} from '../shared/nodes';
-import {transformNodes} from './plugins';
+import { isClass, isFalse, isFunction } from '../shared/nodes';
+import { transformNodes } from './plugins';
 
 async function generateBranch(parent, node, depth, scope) {
 
   transformNodes(scope, node, depth);
 
-  if(isFalse(node)) {
+  if (isFalse(node)) {
     parent.children.push(false);
     return;
   }
 
-  if(isClass(node)) {
-    const key = node.attributes.key || generateKey(depth);
-    if(
-      scope.context.environment.client && 
+  if (isClass(node)) {
+    const key = (node.attributes.key || generateKey(depth)) + (node.attributes.route ? scope.context.router.url : '')
+    if (
+      scope.context.environment.client &&
       scope.context.router._changed &&
-      node.attributes && 
-      node.attributes.route && 
+      node.attributes &&
+      node.attributes.route &&
       scope.context.environment.mode !== 'ssg'
     ) {
       const routeDepth = depth.slice(0, -1).join('.');
       const newSegments = scope.context.router._newSegments[routeDepth];
-      if(newSegments) {
+      if (newSegments) {
         const oldSegments = scope.context.router._oldSegments[routeDepth];
-        for(const segment in newSegments) {
-          if(oldSegments[segment] !== newSegments[segment]) {
+        for (const segment in newSegments) {
+          if (oldSegments[segment] !== newSegments[segment]) {
             delete scope.memory[key];
             delete scope.instances[key];
           }
         }
       }
-    }  
+    }
     const instance = scope.instances[key] || new node.type(scope);
+    instance._self.persistent = !!node.attributes.persistent
     instance._self.key = key;
     instance._attributes = node.attributes;
     instance._scope = scope;
     let memory;
-    if(scope.memory) {
+    if (scope.memory) {
       memory = scope.memory[key];
-      if(memory) {
+      if (memory) {
         instance._self.initiated = true;
         Object.assign(instance, memory);
         delete scope.memory[key];
       }
     }
     let shouldHydrate = false;
+    if (instance._self.terminated) {
+      shouldHydrate = true;
+      instance._self.terminated = false;
+    }
     const shouldPrepare = scope.instances[key] === undefined;
     scope.instances[key] = instance;
-    if(shouldPrepare) {
-      if(memory === undefined) {
+    if (shouldPrepare) {
+      if (memory === undefined) {
         instance.prepare && instance.prepare();
-        if(scope.context.environment.server) {
+        if (scope.context.environment.server) {
           instance.initiate && await instance.initiate();
           instance._self.initiated = true;
         } else {
@@ -61,45 +66,45 @@ async function generateBranch(parent, node, depth, scope) {
       shouldHydrate = true;
     }
     if (scope.hydrationQueue) {
-      if(shouldHydrate) {
+      if (shouldHydrate) {
         scope.hydrationQueue.push(instance);
-      } else if(instance._self.initiated == true) {
+      } else if (instance._self.initiated == true) {
         instance.update && instance.update();
       }
     }
-    if(scope.context.environment.client) {
+    if (scope.context.environment.client) {
       scope.renewalQueue.push(instance);
     }
     const children = instance.render();
-    if(children && children.type) {
+    if (children && children.type) {
       children.instance = instance;
     }
     node.children = [].concat(children);
-    for(let i=0; i<node.children.length; i++) {
+    for (let i = 0; i < node.children.length; i++) {
       await generateBranch(parent, node.children[i], [...depth, i], scope);
     }
     return;
   }
 
-  if(isFunction(node)) {
+  if (isFunction(node)) {
     const context = node.type.name ? scope.generateContext(node.attributes) : node.attributes;
     const children = node.type(context);
     node.children = [].concat(children);
-    for(let i=0; i<node.children.length; i++) {
+    for (let i = 0; i < node.children.length; i++) {
       await generateBranch(parent, node.children[i], [...depth, i], scope);
     }
     return;
   }
 
-  if(node.type) {
+  if (node.type) {
     const branch = {
       type: node.type,
       attributes: node.attributes || {},
       instance: node.instance,
       children: []
     }
-    if(node.children) {
-      for(let i=0; i<node.children.length; i++) {
+    if (node.children) {
+      for (let i = 0; i < node.children.length; i++) {
         await generateBranch(branch, node.children[i], [...depth, i], scope);
       }
     }
@@ -112,7 +117,7 @@ async function generateBranch(parent, node, depth, scope) {
 }
 
 export default async function generateTree(node, scope) {
-  const tree = {type: 'div', attributes: {id: 'application'}, children: []};
+  const tree = { type: 'div', attributes: { id: 'application' }, children: [] };
   await generateBranch(tree, node, [0], scope);
   return tree;
 }

--- a/tests/src/Application.njs
+++ b/tests/src/Application.njs
@@ -29,7 +29,8 @@ import PureComponents from './PureComponents';
 import NestedProxy from './NestedProxy';
 import FalsyNodes from './FalsyNodes';
 import ErrorOnChildNode from './ErrorOnChildNode';
-import Vunerability from './Vunerability.njs';
+import Vunerability from './Vunerability';
+import PersistentComponent from './PersistentComponent';
 
 import './Application.css';
 
@@ -51,7 +52,7 @@ class Application extends Nullstack {
     context.string = 'nullstack';
   }
 
-  render({project, page, environment}) {
+  render({ project, page, environment }) {
     return (
       <main>
         <h1> {project.name} </h1>
@@ -91,6 +92,7 @@ class Application extends Nullstack {
         <FalsyNodes route="/falsy-nodes" />
         <ErrorOnChildNode route="/error-on-child-node" />
         <Vunerability route="/vunerability" />
+        <PersistentComponent route="/persistent-component/:id" persistent />
         <ErrorPage route="*" />
       </main>
     )

--- a/tests/src/InstanceSelf.test.js
+++ b/tests/src/InstanceSelf.test.js
@@ -10,7 +10,7 @@ beforeAll(async () => {
 });
 
 describe('InstanceSelf', () => {
-  
+
   test('self is aware that the component initiated', async () => {
     await page.waitForSelector('[data-initiated]');
     const element = await page.$('[data-initiated]');
@@ -35,9 +35,9 @@ describe('InstanceSelf', () => {
     expect(element).toBeTruthy();
   });
 
-  test('self is aware of the component key', async () => {
-    await page.waitForSelector('[data-key="n-0-0-6"]');
-    const element = await page.$('[data-key="n-0-0-6"]');
+  test('self key has route appended to depth if no key is declared', async () => {
+    await page.waitForSelector('[data-key="n-0-0-6/instance-self"]');
+    const element = await page.$('[data-key="n-0-0-6/instance-self"]');
     expect(element).toBeTruthy();
   });
 
@@ -45,13 +45,13 @@ describe('InstanceSelf', () => {
     await page.waitForSelector('[data-tag="form"]');
     const element = await page.$('[data-tag="form"]');
     expect(element).toBeTruthy();
-  });  
+  });
 
   test('fragments can be nested', async () => {
     await page.waitForSelector('[data-year="1992"]');
     const element = await page.$('[data-year="1992"]');
     expect(element).toBeTruthy();
-  });  
+  });
 
 });
 

--- a/tests/src/Instanceable.njs
+++ b/tests/src/Instanceable.njs
@@ -48,7 +48,7 @@ class Instanceable extends Nullstack {
     )
   }
 
-  render({ instances }) {
+  render({ instances, self }) {
     const { application } = instances;
     const mainHasKey = (
       application &&
@@ -71,6 +71,7 @@ class Instanceable extends Nullstack {
           }
         </div>
         <p data-application-key={mainHasKey}></p>
+        <div data-key={self.key} />
       </div>
     )
   }

--- a/tests/src/Instanceable.test.js
+++ b/tests/src/Instanceable.test.js
@@ -40,6 +40,12 @@ describe('Instanceable', () => {
     expect(p).toBeTruthy();
   });
 
+  test('self key ignores the route suffix if a key is declared', async () => {
+    await page.waitForSelector('[data-key="instanceable"]');
+    const element = await page.$('[data-key="instanceable"]');
+    expect(element).toBeTruthy();
+  });
+
 });
 
 afterAll(async () => {

--- a/tests/src/PersistentComponent.njs
+++ b/tests/src/PersistentComponent.njs
@@ -1,0 +1,22 @@
+import Nullstack from 'nullstack';
+
+class PersistentComponent extends Nullstack {
+
+  count = 0
+
+  async hydrate() {
+    this.count++
+  }
+
+  render() {
+    return (
+      <div data-count={this.count}>
+        <a href="/persistent-component/a"> a </a>
+        <a href="/persistent-component/b"> b </a>
+      </div>
+    )
+  }
+
+}
+
+export default PersistentComponent;

--- a/tests/src/PersistentComponent.njs
+++ b/tests/src/PersistentComponent.njs
@@ -4,13 +4,26 @@ class PersistentComponent extends Nullstack {
 
   count = 0
 
+  prepare() {
+    this.count = -1;
+  }
+
+  initiate() {
+    this.count = -1;
+  }
+
   async hydrate() {
     this.count++
   }
 
-  render() {
+  terminate() {
+    this.count++
+  }
+
+  render({ self, instances }) {
+    const aCount = instances['n-0-0-33/persistent-component/a']?.count
     return (
-      <div data-count={this.count}>
+      <div data-count={this.count} data-key={self.key} data-a-count={aCount}>
         <a href="/persistent-component/a"> a </a>
         <a href="/persistent-component/b"> b </a>
       </div>

--- a/tests/src/PersistentComponent.test.js
+++ b/tests/src/PersistentComponent.test.js
@@ -1,0 +1,96 @@
+const puppeteer = require('puppeteer');
+
+let browser;
+
+beforeAll(async () => {
+  browser = await puppeteer.launch();
+});
+
+
+describe('PersistentComponent instantiated', () => {
+
+  let page;
+
+  beforeAll(async () => {
+    page = await browser.newPage();
+    await page.goto('http://localhost:6969/persistent-component/a');
+  });
+
+  test('components should create a new instance when matching a dynamic segment', async () => {
+    await page.waitForSelector('[data-key="n-0-0-33/persistent-component/a"]');
+    const element = await page.$('[data-key="n-0-0-33/persistent-component/a"]');
+    expect(element).toBeTruthy();
+  });
+
+});
+
+describe('PersistentComponent terminated', () => {
+
+  let page;
+
+  beforeAll(async () => {
+    page = await browser.newPage();
+    await page.goto('http://localhost:6969/persistent-component/a');
+    await page.waitForSelector('[href="/persistent-component/b"]');
+    await page.click('[href="/persistent-component/b"]');
+    await page.waitForSelector('[data-key="n-0-0-33/persistent-component/b"]');
+  });
+
+  test('components should call terminate when leaving the dom', async () => {
+    await page.waitForSelector('[data-a-count="1"]');
+    const element = await page.$('[data-a-count="1"]');
+    expect(element).toBeTruthy();
+  });
+
+  test('persistent instanes should stay on instances context when leaving the dom', async () => {
+    await page.waitForSelector('[data-a-count="1"]');
+    const element = await page.$('[data-a-count="1"]');
+    expect(element).toBeTruthy();
+  });
+
+});
+
+describe('PersistentComponent reinstantiated', () => {
+
+  let page;
+
+  beforeAll(async () => {
+    page = await browser.newPage();
+    await page.goto('http://localhost:6969/persistent-component/a');
+    await page.waitForSelector('[href="/persistent-component/b"]');
+    await page.click('[href="/persistent-component/b"]');
+    await page.waitForSelector('[data-key="n-0-0-33/persistent-component/b"]');
+    await page.click('[href="/persistent-component/a"]');
+    await page.waitForSelector('[data-key="n-0-0-33/persistent-component/a"]');
+  });
+
+  test('components should not be prepared a second time', async () => {
+    await page.waitForSelector('[data-count="2"]');
+    const element = await page.$('[data-count="2"]');
+    expect(element).toBeTruthy();
+  });
+
+  test('components should not be initiated a second time', async () => {
+    await page.waitForSelector('[data-count="2"]');
+    const element = await page.$('[data-count="2"]');
+    expect(element).toBeTruthy();
+  });
+
+  test('components should call hydrate when reinstantiated', async () => {
+    await page.waitForSelector('[data-count="2"]');
+    const element = await page.$('[data-count="2"]');
+    expect(element).toBeTruthy();
+  });
+
+  test('components should keep the old state', async () => {
+    await page.waitForSelector('[data-count="2"]');
+    const element = await page.$('[data-count="2"]');
+    expect(element).toBeTruthy();
+  });
+
+});
+
+afterAll(async () => {
+  browser.close();
+});
+

--- a/tests/src/RoutesAndParams.njs
+++ b/tests/src/RoutesAndParams.njs
@@ -5,16 +5,17 @@ class RoutesAndParams extends Nullstack {
   eventTriggered = false;
   paramHydrated = false;
 
-  hydrate({router, params}) {
+  hydrate(context) {
+    const { router, params } = context;
     this.paramHydrated = params.id === 'a';
     window.addEventListener(router.event, () => {
-      this.eventTriggered = true;
+      context.eventTriggered = true;
     });
   }
 
-  renderOther({params}) {
+  renderOther({ params }) {
     return (
-      <div> 
+      <div>
         <div data-other />
         <div data-a route="/routes-and-params/a" />
         <div data-id={params.id} route="*" />
@@ -28,27 +29,27 @@ class RoutesAndParams extends Nullstack {
     )
   }
 
-  setParamsDate({params}) {
+  setParamsDate({ params }) {
     params.date = new Date('1992-10-16');
   }
-  
+
   goToDocs({ router }) {
     router.url = 'https://nullstack.app';
   }
 
-  render({router, params}) {
+  render({ router, params, eventTriggered }) {
     return (
-      <div> 
+      <div>
         <a href="https://nullstack.app"> Nullstack</a>
         <button data-absolute onclick={this.goToDocs}> Nullstack </button>
         <a href="/routes-and-params/no-hash#hash">hash</a>
-        <div data-event-triggered={this.eventTriggered} />
+        <div data-event-triggered={eventTriggered} />
         <div data-router={!!router} />
         <div route="/routes-and-params" data-route="/routes-and-params" />
         <Other route="/routes-and-params/:id" />
         <Wildcard route="/routes-and-params/*" />
         <a href="/routes-and-params/a"> a </a>
-        <a params={{framework: 'nullstack'}}> string </a>
+        <a params={{ framework: 'nullstack' }}> string </a>
         <a path="/routes-and-params/d"> path </a>
         <div data-url={router.url} />
         <div data-path={router.path} />


### PR DESCRIPTION
tests missing:

- [x] routes with keys should have the url suffixed on the key
- [x] components should have a terminated key on self
- [x] reinstantiating a persistent component should have the old state
- [x] permanent components should call hydrate on reinstantiate 
- [x] permanent components should but skip prepare on reinstantiate
- [x] permanent components should but skip initiate on reinstantiate
- [x] permanente componentes should be terminanted
- [x] permanent component instances should be available on instances when the component is terminanted