### PR TITLE
Rename Proxy functions

### DIFF
--- a/client/instanceProxyHandler.js
+++ b/client/instanceProxyHandler.js
@@ -6,10 +6,13 @@ const instanceProxyHandler = {
   get(target, name) {
     if(name === '_isProxy') return true;
     if(typeof(target[name]) == 'function' && !target[name].name.startsWith('_') && name !== 'constructor') {
-      return (args) => {
+      const {[name]: func} = {
+        [name]: (args) => {
         const context = generateContext({...target._attributes, ...args, self: target._self});
         return target[name](context);
+        }
       }
+      return func;
     }
     return Reflect.get(...arguments);
   },


### PR DESCRIPTION
This rename functions on Proxy

Useful on browser devtools call stack
* Before
![image](https://user-images.githubusercontent.com/10155152/133785725-b42800af-1f12-4579-8a5c-f1a9a291e768.png)

* After
![image](https://user-images.githubusercontent.com/10155152/133785885-a58c5e16-5f92-4c9e-8782-f15aecb41e08.png)

And useful on Devtools Nullstack (under development)