### PR TITLE
Exit CI on build error

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -61,7 +61,7 @@ function build({ input, output, mode = 'ssr' }) {
   console.log(` 🚀️ Building your application in ${mode} mode...`);
   compiler.run((error, stats) => {
     logTrace(stats, false);
-    if (stats.hasErrors()) return;
+    if (stats.hasErrors()) process.exit(1);
     require(`../builders/${mode}`)(output);
   });
 }


### PR DESCRIPTION
This ***big*** PR changes the way a production build error exits (focusing on failing CI ones)
Taking Vercel as example, currently a error (e.g: syntax) happens like this:

![ci-build-not-exiting](https://user-images.githubusercontent.com/31557312/149908689-3ff02592-c050-4c6d-9f78-ea234f2c3b2c.png)

ending on simply deploying (with success) a broken app to production.
With this PR it does the following:

![ci-build-exiting](https://user-images.githubusercontent.com/31557312/149909133-367bc52c-85ea-45c5-8d08-1266307142f8.png)

Straightfully avoiding a broken deploy (as expected? :thinking:)