### PR TITLE
Run build before running tests

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "start": "npx nullstack start --input=./tests --port=6969",
     "build": "npx nullstack build --input=./tests --mode=ssr",
-    "test": "jest --testTimeout=20000",
+    "test": "npm run build && jest --testTimeout=20000",
     "script": "node src/scripts/run.js"
   },
   "dependencies": {

--- a/tests/src/Purge.test.js
+++ b/tests/src/Purge.test.js
@@ -1,13 +1,10 @@
 const { readFileSync } = require('fs');
-const { promisify } = require('util');
-const exec = promisify(require('child_process').exec);
 
 let css;
 
 const unused = '.unused'
 
 beforeAll(async () => {
-  await exec('npm run build');
   css = readFileSync('.production/client.css', 'utf-8')
 });
 


### PR DESCRIPTION
For testing [Purge](https://github.com/nullstack/nullstack/blob/master/tests/src/Purge.test.js) looks like it would be better to decouple the heavy full build from the tests run.

On local machine currently the tests always timeout, for example.
If we'll be testing the build results anyway, best to run it before all tests.