### PR TITLE
Replace inexistent `rmSync` with `removeSync` on builds

### DIFF
--- a/builders/spa.js
+++ b/builders/spa.js
@@ -3,7 +3,7 @@ module.exports = async function spa(folder = 'spa') {
 
   const dir = process.cwd();
   const application = require(`${dir}/.production/server`).default
-  const { existsSync, mkdirSync, writeFileSync, copySync, rmSync } = require('fs-extra');
+  const { existsSync, mkdirSync, writeFileSync, copySync, removeSync } = require('fs-extra');
   const path = `${dir}/${folder}`;
 
   async function copy(url, file) {
@@ -19,7 +19,7 @@ module.exports = async function spa(folder = 'spa') {
 
   console.log()
   if (existsSync(path)) {
-    rmSync(path, { recursive: true });
+    removeSync(path);
   }
   mkdirSync(path)
   console.log(` ⚙️  /public/`)

--- a/builders/ssg.js
+++ b/builders/ssg.js
@@ -4,7 +4,7 @@ module.exports = async function ssg(folder = 'ssg') {
   const dir = process.cwd();
   const application = require(`${dir}/.production/server`).default;
   const { resolve } = require('path')
-  const { existsSync, mkdirSync, writeFileSync, copySync, rmSync } = require('fs-extra');
+  const { existsSync, mkdirSync, writeFileSync, copySync, removeSync } = require('fs-extra');
 
   function path(file = '') {
     const target = file.startsWith('/') ? file.slice(1) : file;
@@ -85,7 +85,7 @@ module.exports = async function ssg(folder = 'ssg') {
 
   console.log()
   if (existsSync(path())) {
-    rmSync(path(), { recursive: true });
+    removeSync(path());
   }
   mkdirSync(path())
   console.log(` ⚙️  /public/`)


### PR DESCRIPTION
For some curious reason, `fs-extra` includes `fs` types but not all it's functions.
`rmSync` is an example, they only use it internally on `removeSync` with fixed options (`recursive` & `force`).

Without this change, the alternative builds (ssg & spa) breaks when trying to `rmSync` an old build.

btw, it allows Netlify CI to finally build/rebuild a project like our docs:
https://app.netlify.com/sites/nullstack-docs/deploys