### PR TITLE
Add tests for html-injected links wrongly refreshing

### DIFF
--- a/tests/src/RoutesAndParams.njs
+++ b/tests/src/RoutesAndParams.njs
@@ -4,6 +4,8 @@ class RoutesAndParams extends Nullstack {
 
   eventTriggered = false;
   paramHydrated = false;
+  shownLink = true;
+  htmlLinkBtn = '';
 
   hydrate(context) {
     const { router, params } = context;
@@ -11,6 +13,8 @@ class RoutesAndParams extends Nullstack {
     window.addEventListener(router.event, () => {
       context.eventTriggered = true;
     });
+    this.shownLink = !params.hideLink;
+    this.htmlLinkBtn = 'click';
   }
 
   renderOther({ params }) {
@@ -26,6 +30,22 @@ class RoutesAndParams extends Nullstack {
   renderWildcard() {
     return (
       <div data-wildcard />
+    )
+  }
+
+  renderInnerHTML({ params, route }) {
+    const html = `
+      <a href="${route}?hideLink=${params.hideLink}"> innerHTML </a>
+    `
+    return (
+      <div data-shown-link={this.shownLink}>
+        <button
+          onclick={{shownLink: true, htmlLinkBtn: 'clicked'}}
+          data-show-link={this.htmlLinkBtn}
+          html={this.htmlLinkBtn}
+        />
+        <div html={this.shownLink ? html : ''} />
+      </div>
     )
   }
 
@@ -46,6 +66,7 @@ class RoutesAndParams extends Nullstack {
         <div data-event-triggered={eventTriggered} />
         <div data-router={!!router} />
         <div route="/routes-and-params" data-route="/routes-and-params" />
+        <InnerHTML route="/routes-and-params/inner-html" />
         <Other route="/routes-and-params/:id" />
         <Wildcard route="/routes-and-params/*" />
         <a href="/routes-and-params/a"> a </a>

--- a/tests/src/RoutesAndParams.test.js
+++ b/tests/src/RoutesAndParams.test.js
@@ -230,3 +230,30 @@ describe('RoutesAndParams /routes-and-params?previous=true', () => {
   });
 
 });
+
+describe('RoutesAndParams /routes-and-params/inner-html', () => {
+
+  const htmlRoute = 'routes-and-params/inner-html?hideLink=';
+
+  async function redirectAndKeepState(hiddenLink = '') {
+    await page.goto(`http://localhost:6969/${htmlRoute}${hiddenLink}`);
+    await page.waitForSelector('[data-show-link="click"]');
+    await page.click('[data-show-link="click"]');
+    await page.waitForSelector('[data-show-link="clicked"]');
+    await page.waitForSelector('[data-shown-link]');
+    await page.waitForSelector(`[href="/${htmlRoute}${hiddenLink}"]`);
+    await page.click(`[href="/${htmlRoute}${hiddenLink}"]`);
+    return page.$('[data-show-link="clicked"]');
+  }
+
+  test('html route injected from start do not refresh', async () => {
+    const element = await redirectAndKeepState();
+    expect(element).toBeTruthy();
+  });
+
+  test('html route injected after first render do not refresh', async () => {
+    const element = await redirectAndKeepState('true');
+    expect(element).toBeTruthy();
+  });
+
+});


### PR DESCRIPTION
This addition of tests shows that html-injected links after first render wrongly fully refreshes page (contrary of the behavior from before)