### PR TITLE
Added support to tailwind arbitrary classes

### DIFF
--- a/tests/src/Application.css
+++ b/tests/src/Application.css
@@ -2,6 +2,11 @@
   display: block;
 }
 
+
+:root {
+  --custom-var-value: red;
+}
+
 .class-\[custom\] {
   background: red;
 }
@@ -20,4 +25,8 @@
 
 .should-be-removed {
   background: yellow;
+}
+
+.\[color\:var\(--custom-var-value\)\] {
+  color: var(--custom-var-value);
 }

--- a/tests/src/Purge.njs
+++ b/tests/src/Purge.njs
@@ -4,7 +4,7 @@ class Purge extends Nullstack {
 
   render() {
     return (
-      <div class="class class-[custom] class-0.5"> Purge </div>
+      <div class="class class-[custom] [color:var(--custom-var-value)] class-0.5"> Purge </div>
     )
   }
 

--- a/tests/src/Purge.test.js
+++ b/tests/src/Purge.test.js
@@ -20,6 +20,11 @@ describe('.production', () => {
     expect(hasClass).toBeTruthy();
   })
 
+  test('used classes with arbitraty value and variable stay after purge', async () => {
+    const hasClass = css.includes('\\[color\\:var\\(--custom-var-value\\)\\]')
+    expect(hasClass).toBeTruthy();
+  })
+
   test('used classes with dots stay after purge', async () => {
     const hasClass = css.includes('.class-0\\.5')
     expect(hasClass).toBeTruthy();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -223,7 +223,7 @@ function client(env, argv) {
       paths: glob.sync(`src/**/*`, { nodir: true }),
       content: ['./**/*.njs'],
       safelist: ['script', 'body', 'html', 'style'],
-      defaultExtractor: content => content.match(/[\w-/:\\\.\[\]\(\)]+(?<!:)/g) || [],
+      defaultExtractor: content => content.match(/[^<>"'`\s]*[^<>"'`\s:]/g) || [],
     }));
   }
   return {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -223,7 +223,7 @@ function client(env, argv) {
       paths: glob.sync(`src/**/*`, { nodir: true }),
       content: ['./**/*.njs'],
       safelist: ['script', 'body', 'html', 'style'],
-      defaultExtractor: content => content.match(/[\w-/:\\\.\[\]]+(?<!:)/g) || [],
+      defaultExtractor: content => content.match(/[\w-/:\\\.\[\]\(\)]+(?<!:)/g) || [],
     }));
   }
   return {


### PR DESCRIPTION
Using Tailwind purge regex: https://v2.tailwindcss.com/docs/optimizing-for-production#writing-purgeable-html

⚠️ Flow SDK doesn't support Webpack 5. You can follow the issue here: https://github.com/onflow/fcl-js/issues/982