### PR TITLE
Little webpack config improvements

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -89,9 +89,9 @@ const nullstackTypescript = {
 };
 
 function server(env, argv) {
-  const dir = argv.input || '../..';
+  const dir = argv.input ? path.join(__dirname, argv.input) : process.cwd();
   const icons = {};
-  const publicFiles = readdirSync(path.join(__dirname, dir, 'public'));
+  const publicFiles = readdirSync(path.join(dir, 'public'));
   for (const file of publicFiles) {
     if (file.startsWith('icon-')) {
       const size = file.split('x')[1].split('.')[0];
@@ -113,7 +113,7 @@ function server(env, argv) {
     mode: argv.environment,
     entry: './server.js',
     output: {
-      path: path.resolve(__dirname, dir + '/' + folder + '/'),
+      path: path.join(dir, folder),
       filename: 'server.js',
       libraryTarget: 'umd'
     },
@@ -199,7 +199,7 @@ function server(env, argv) {
 }
 
 function client(env, argv) {
-  const dir = argv.input || '../..';
+  const dir = argv.input ? path.join(__dirname, argv.input) : process.cwd();
   const folder = argv.environment === 'development' ? '.development' : '.production';
   const devtool = argv.environment === 'development' ? 'inline-cheap-module-source-map' : false;
   const minimize = argv.environment !== 'development';
@@ -225,7 +225,7 @@ function client(env, argv) {
     entry: './client.js',
     output: {
       publicPath: `/`,
-      path: path.resolve(__dirname, dir + '/' + folder + '/'),
+      path: path.join(dir, folder),
       filename: 'client.js'
     },
     optimization: {
@@ -243,7 +243,6 @@ function client(env, argv) {
     stats: 'errors-only',
     module: {
       rules: [
-
         {
           test: /nullstack.js$/,
           loader: 'string-replace-loader',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,7 @@ const babel = {
     extensions: ['.njs', '.js', '.nts', '.ts']
   },
   use: {
-    loader: 'babel-loader',
+    loader: require.resolve('babel-loader'),
     options: {
       "presets": [
         ["@babel/preset-env", { "targets": { node: "10" } }]
@@ -45,7 +45,7 @@ const nullstackJavascript = {
     extensions: ['.njs', '.js', '.nts', '.ts']
   },
   use: {
-    loader: 'babel-loader',
+    loader: require.resolve('babel-loader'),
     options: {
       "presets": [
         ["@babel/preset-env", { "targets": { node: "10" } }],
@@ -70,7 +70,7 @@ const nullstackTypescript = {
     extensions: ['.njs', '.js', '.nts', '.ts']
   },
   use: {
-    loader: 'babel-loader',
+    loader: require.resolve('babel-loader'),
     options: {
       "presets": [
         ["@babel/preset-env", { "targets": { node: "10" } }],
@@ -136,7 +136,7 @@ function server(env, argv) {
       rules: [
         {
           test: /nullstack.js$/,
-          loader: 'string-replace-loader',
+          loader: require.resolve('string-replace-loader'),
           options: {
             multiple: [
               { search: '{{NULLSTACK_ENVIRONMENT_NAME}}', replace: 'server', flags: 'ig' }
@@ -145,7 +145,7 @@ function server(env, argv) {
         },
         {
           test: /environment.js$/,
-          loader: 'string-replace-loader',
+          loader: require.resolve('string-replace-loader'),
           options: {
             multiple: [
               { search: '{{NULLSTACK_ENVIRONMENT_KEY}}', replace: buildKey, flags: 'ig' }
@@ -154,7 +154,7 @@ function server(env, argv) {
         },
         {
           test: /project.js$/,
-          loader: 'string-replace-loader',
+          loader: require.resolve('string-replace-loader'),
           options: {
             multiple: [
               { search: '{{NULLSTACK_PROJECT_ICONS}}', replace: JSON.stringify(icons), flags: 'ig' }
@@ -174,7 +174,7 @@ function server(env, argv) {
         {
           test: /\.s?[ac]ss$/,
           use: [
-            { loader: 'ignore-loader' }
+            { loader: require.resolve('ignore-loader') }
           ]
         },
         nullstackTypescript,
@@ -208,7 +208,7 @@ function client(env, argv) {
     liveReload = {
       test: /liveReload.js$/,
       use: [
-        { loader: 'ignore-loader' }
+        { loader: require.resolve('ignore-loader') }
       ]
     }
   }
@@ -245,7 +245,7 @@ function client(env, argv) {
       rules: [
         {
           test: /nullstack.js$/,
-          loader: 'string-replace-loader',
+          loader: require.resolve('string-replace-loader'),
           options: {
             multiple: [
               { search: '{{NULLSTACK_ENVIRONMENT_NAME}}', replace: 'client', flags: 'ig' }
@@ -270,8 +270,8 @@ function client(env, argv) {
           test: /\.s?[ac]ss$/,
           use: [
             MiniCssExtractPlugin.loader,
-            { loader: 'css-loader', options: { url: false } },
-            { loader: 'sass-loader' }
+            { loader: require.resolve('css-loader'), options: { url: false } },
+            { loader: require.resolve('sass-loader') }
           ],
         },
         liveReload,


### PR DESCRIPTION
Together with each commit description, some notes:
- [Default to cwd() in webpack config](https://github.com/nullstack/nullstack/commit/fd0a56763e8d3d2011d6bdaedb906bd5c1eb3adc):
In day-to-day and custom environments, the `input` flag becomes a problem/unpredictable, e.g. when using pnpm the path from config to my project is exotic, and we already depend on polemic `cwd()` at [builders](https://github.com/nullstack/nullstack/tree/master/builders), so.. :)
- [Use Node own pkg-resolve for loaders path](https://github.com/nullstack/nullstack/commit/5f159c21526ac53d707659e86b20bf32a41b0954):
We're depending on whatever the webpack internal resolve is, being unpredictable and breaks on custom environments, e.g. pnpm packages and their exotic paths.