### PR TITLE
Fix decoding & Add MetatagState test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nullstack",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Full-stack Javascript Components for one-dev armies",
   "main": "nullstack.js",
   "author": "Mortaro",

--- a/tests/src/Application.njs
+++ b/tests/src/Application.njs
@@ -44,6 +44,7 @@ import UnderscoredAttributes from './UnderscoredAttributes';
 import Vunerability from './Vunerability';
 import WindowDependency from './WindowDependency';
 import WorkerVerbs from './WorkerVerbs';
+import MetatagState from './MetatagState';
 
 class Application extends Nullstack {
 
@@ -109,6 +110,7 @@ class Application extends Nullstack {
         <WebpackCustomPlugin route="/webpack-custom-plugin" />
         <ComponentTernary route="/component-ternary" />
         <AnchorModifiers route="/anchor-modifiers" />
+        <MetatagState route="/metatag-state" />
         <ErrorPage route="*" />
       </main>
     )

--- a/tests/src/MetatagState.njs
+++ b/tests/src/MetatagState.njs
@@ -1,0 +1,15 @@
+import Nullstack from 'nullstack';
+
+class MetatagState extends Nullstack {
+
+  html = '&quot;nullstack&quot;';
+
+  render() {
+    return (
+      <div html={this.html}/>
+    )
+  }
+
+}
+
+export default MetatagState;

--- a/tests/src/MetatagState.test.js
+++ b/tests/src/MetatagState.test.js
@@ -1,0 +1,19 @@
+let hasConsoleError = false;
+let originalConsole = console.error;
+
+beforeAll(async () => {
+  console.error = jest.fn(() => hasConsoleError = true);
+  await page.goto('http://localhost:6969/metatag-state');
+});
+
+describe('MetatagState', () => {
+
+  test('state stored at metatag can be retrieved without errors', async () => {
+    expect(hasConsoleError).toBeFalsy();
+  });
+
+});
+
+afterAll(async () => {
+  console.error = originalConsole;
+});

--- a/tests/src/RenderableComponent.njs
+++ b/tests/src/RenderableComponent.njs
@@ -22,7 +22,7 @@ class RenderableComponent extends Nullstack {
 
   render({ params }) {
     const list = params.shortList ? [1, 2, 3] : [1, 2, 3, 4, 5, 6]
-    const html = '<a href="/"> "Nullstack" </a>';
+    const html = '<a href="/"> Nullstack </a>';
     return (
       <div class="RenderableComponent">
         <Falsy />

--- a/workers/staticHelpers.js
+++ b/workers/staticHelpers.js
@@ -9,7 +9,7 @@ async function extractData(response) {
   const html = await response.clone().text();
   const stateLookup = '<meta name="nullstack" content="';
   const state = html.split("\n").find((line) => line.indexOf(stateLookup) > -1).split(stateLookup)[1].slice(0, -2);
-  const { instances, page } = JSON.parse(decodeURI(state));
+  const { instances, page } = JSON.parse(decodeURIComponent(state));
   const json = JSON.stringify({ instances, page });
   return new Response(json, {
     headers: { 'Content-Type': 'application/json' }


### PR DESCRIPTION
The test really needed to be moved to his own page, taking into account that it simply breaks all rendering around o.o

And in a nutshell, it was coming from some sort of parsing from the browser in the meta tag, when quotes are stored there with `encodeURI` (after first request) it becomes a thing that just breaks when equally decoding (`encodeURIComponent` to the rescue!)