### PR TITLE
Add support for absolute links and router paths

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -63,10 +63,11 @@ class Router {
   }
 
   async _redirect(target) {
-    if (target.startsWith('http')) {
+    if (/^(\w+:|\/\/)([^.]+.)/.test(target)) {
       return (window.location.href = target);
     }
-    const { url, hash, urlWithHash } = extractLocation(target);
+    const absoluteUrl = new URL(target, document.baseURI);
+    const { url, hash, urlWithHash } = extractLocation(absoluteUrl.pathname + absoluteUrl.search + absoluteUrl.hash);
     if (url !== this._url || this._hash !== hash) {
       await this._update(urlWithHash, true);
     }

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,11 +5,11 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "jest": "^26.6.3",
+    "glob": "^8.0.3",
+    "jest": "^28.1.0",
+    "jest-puppeteer": "^6.1.0",
     "nullstack": "*",
-    "puppeteer": "^5.5.0",
-    "jest-puppeteer": "^6.0.3",
-    "glob": "^7.1.7",
+    "puppeteer": "^14.1.1",
     "purgecss-webpack-plugin": "^4.1.3"
   },
   "scripts": {

--- a/tests/src/RoutesAndParams.njs
+++ b/tests/src/RoutesAndParams.njs
@@ -3,6 +3,32 @@ class RoutesAndParams extends Nullstack {
 
   paramHydrated = false;
 
+  initiate({ router, params }) {
+    if (params.parent) {
+      router.url = '../parent'
+    } else if (params.current) {
+      router.url = './current'
+    } else if (params.https) {
+      router.url = 'https://nullstack.app/'
+    } else if (params.http) {
+      router.url = 'http://localhost:6969/http'
+    } else if (params.same) {
+      router.url = '//localhost:6969/routes-and-params/href-same-protocol'
+    } else if (params.ftp) {
+      router.url = 'ftp://nullstack.app/'
+    } else if (params.tel) {
+      router.url = 'tel:1555696969'
+    } else if (params.mailto) {
+      router.url = 'mailto:contact@nullstack.app'
+    } else if (params.relative) {
+      router.url = 'relative'
+    } else if (params.relativeComposed) {
+      router.url = 'relative/6969'
+    } else if (params.root) {
+      router.url = '/root/6969'
+    }
+  }
+
   hydrate(context) {
     const { router, params } = context;
     this.paramHydrated = params.id === 'a';
@@ -48,10 +74,28 @@ class RoutesAndParams extends Nullstack {
     router.url = 'https://nullstack.app';
   }
 
+  renderHrefs() {
+    return (
+      <>
+        <a href="https://nullstack.app/"> Nullstack HTTPS</a>
+        <a href="http://nullstack.app/"> Nullstack HTTP</a>
+        <a href="//nullstack.app/"> Nullstack SAME</a>
+        <a href="ftp://nullstack.app/" data-ftp-clicked={this.clickedFtp} onclick={{ clickedFtp: true }}> Nullstack FTP</a>
+        <a href="tel:1555696969" data-tel-clicked={this.clickedTel} onclick={{ clickedTel: true }}> Nullstack TEL</a>
+        <a href="mailto:contact@nullstack.app" data-mailto-clicked={this.clickedMailTo} onclick={{ clickedMailTo: true }}> Nullstack MAILTO</a>
+        <a href="relative"> Nullstack RELATIVE</a>
+        <a href="relative/6969"> Nullstack RELATIVE TWO</a>
+        <a href="/root/6969"> Nullstack ROOT</a>
+        <a href="./current"> Nullstack CURRENT DIR</a>
+        <a href="../parent"> Nullstack PARENT DIR</a>
+      </>
+    )
+  }
+
   render({ router, params, eventTriggered, self }) {
     return (
       <div>
-        <a href="https://nullstack.app"> Nullstack</a>
+        <Hrefs />
         <button data-absolute onclick={this.goToDocs}> Nullstack </button>
         <a href="/routes-and-params/no-hash#hash">hash</a>
         <div data-hydrated={self.hydrated} data-event-triggered={eventTriggered} />

--- a/tests/src/RoutesAndParams.test.js
+++ b/tests/src/RoutesAndParams.test.js
@@ -1,3 +1,10 @@
+beforeAll(async () => {
+  await page.on('dialog', async dialog => {
+    await dialog.dismiss();
+  })
+  // page.on('console', (msg) => console.log('[LOG]', msg.text()))
+});
+
 describe('RoutesAndParams /routes-and-params', () => {
 
   beforeAll(async () => {
@@ -200,21 +207,6 @@ describe('RoutesAndParams /routes-and-params', () => {
   });
 
   test('a with absolute hrefs cause a hard redirect', async () => {
-    await page.click('[href="https://nullstack.app"]');
-    await page.waitForSelector('[href="/contributors"]');
-    const url = await page.url();
-    expect(url).toMatch('https://nullstack.app');
-  });
-
-});
-
-describe('RoutesAndParams /routes-and-params', () => {
-
-  beforeAll(async () => {
-    await page.goto('http://localhost:6969/routes-and-params');
-  });
-
-  test('a with absolute hrefs cause a hard redirect', async () => {
     await page.click('[data-absolute]');
     await page.waitForSelector('[href="/contributors"]');
     const url = await page.url();
@@ -273,6 +265,211 @@ describe('RoutesAndParams /routes-and-params/inner-html', () => {
     await page.waitForSelector(`[data-html-clicked]`);
     const element = await page.$('[data-html-clicked]');
     expect(element).toBeTruthy();
+  });
+
+});
+
+describe('RoutesAndParams /routes-and-params/hrefs', () => {
+
+  beforeEach(async () => {
+    await page.goto('http://localhost:6969/routes-and-params/hrefs');
+  });
+
+  test('https urls do a full redirect', async () => {
+    await Promise.all([
+      page.click('[href="https://nullstack.app/"]'),
+      page.waitForNavigation(),
+    ]);
+    const url = await page.url();
+    expect(url).toMatch('://nullstack.app');
+  });
+
+  test('http urls do a full redirect', async () => {
+    await Promise.all([
+      page.click('[href="http://nullstack.app/"]'),
+      page.waitForNavigation(),
+    ]);
+    const url = await page.url();
+    expect(url).toMatch('://nullstack.app');
+  });
+
+  test('// urls do a full redirect', async () => {
+    await Promise.all([
+      page.click('[href="//nullstack.app/"]'),
+      page.waitForNavigation(),
+    ]);
+    const url = await page.url();
+    expect(url).toMatch('://nullstack.app');
+  });
+
+  test('ftp urls do not redirect', async () => {
+    await page.click('[href="ftp://nullstack.app/"]'),
+    await page.waitForSelector('[data-ftp-clicked]');
+    const element = await page.$('[data-ftp-clicked]');
+    expect(element).toBeTruthy();
+  });
+
+  test('tel urls do not redirect', async () => {
+    await page.click('[href="tel:1555696969"]'),
+    await page.waitForSelector('[data-tel-clicked]');
+    const element = await page.$('[data-tel-clicked]');
+    expect(element).toBeTruthy();
+  });
+
+  test('mailto urls do not redirect', async () => {
+    await page.click('[href="mailto:contact@nullstack.app"]'),
+    await page.waitForSelector('[data-mailto-clicked]');
+    const element = await page.$('[data-mailto-clicked]');
+    expect(element).toBeTruthy();
+  });
+
+  test('relative urls redirect', async () => {
+    await Promise.all([
+       page.click('[href="relative"]'),
+       page.waitForNavigation(),
+    ])
+    const url = await page.url();
+    expect(url).toEqual('http://localhost:6969/routes-and-params/relative');
+  });
+  
+  test('relative composed urls redirect', async () => {
+    await Promise.all([
+       page.click('[href="relative/6969"]'),
+       page.waitForNavigation(),
+    ])
+    const url = await page.url();
+    expect(url).toEqual('http://localhost:6969/routes-and-params/relative/6969');
+  });
+
+  test('root urls redirect', async () => {
+    await Promise.all([
+       page.click('[href="/root/6969"]'),
+       page.waitForNavigation(),
+    ])
+    const url = await page.url();
+    expect(url).toEqual('http://localhost:6969/root/6969');
+  });
+
+  test('current urls redirect', async () => {
+    await Promise.all([
+       page.click('[href="./current"]'),
+       page.waitForNavigation(),
+    ])
+    const url = await page.url();
+    expect(url).toEqual('http://localhost:6969/routes-and-params/current');
+  });
+
+  test('parent urls redirect', async () => {
+    await Promise.all([
+       page.click('[href="../parent"]'),
+       page.waitForNavigation(),
+    ])
+    const url = await page.url();
+    expect(url).toEqual('http://localhost:6969/parent');
+  });
+
+});
+
+
+describe('ssr RoutesAndParams /routes-and-params/hrefs', () => {
+
+  test('ssr parent', async () => {
+    await Promise.all([
+      page.goto('http://localhost:6969/routes-and-params/hrefs?parent=1'),
+      page.waitForNavigation(),
+    ]);
+    const url = await page.url();
+    expect(url).toEqual('http://localhost:6969/parent');
+  });
+  
+  test('ssr current', async () => {
+    await Promise.all([
+      page.goto('http://localhost:6969/routes-and-params/hrefs?current=1'),
+      page.waitForNavigation(),
+    ]);
+    const url = await page.url();
+    expect(url).toEqual('http://localhost:6969/routes-and-params/current');
+  });
+  
+  test('ssr https', async () => {
+    await Promise.all([
+      page.goto('http://localhost:6969/routes-and-params/hrefs?https=1'),
+      page.waitForNavigation(),
+    ]);
+    const url = await page.url();
+    expect(url).toEqual('https://nullstack.app/');
+  });
+
+  test('ssr http', async () => {
+    await Promise.all([
+      page.goto('http://localhost:6969/routes-and-params/hrefs?http=1'),
+      page.waitForNavigation(),
+    ]);
+    const url = await page.url();
+    expect(url).toEqual('http://localhost:6969/http');
+  });
+  
+  test('ssr same', async () => {
+    await Promise.all([
+      page.goto('http://localhost:6969/routes-and-params/hrefs?same=1'),
+      page.waitForNavigation(),
+    ]);
+    const url = await page.url();
+    expect(url).toEqual('http://localhost:6969/routes-and-params/href-same-protocol');
+  });
+  
+  // test.skip('ssr ftp', async () => {
+  //   await Promise.all([
+  //     page.goto('http://localhost:6969/routes-and-params/hrefs?ftp=1'),
+  //     page.waitForNavigation(),
+  //   ]);
+  //   const url = await page.url();
+  //   expect(url).toEqual('https://nullstack.app/');
+  // });
+
+  // test.skip('ssr tel', async () => {
+  //   await Promise.all([
+  //     page.goto('http://localhost:6969/routes-and-params/hrefs?tel=1'),
+  //     page.waitForNavigation(),
+  //   ]);
+  //   const url = await page.url();
+  //   expect(url).toEqual('https://nullstack.app/');
+  // });
+  
+  // test.skip('ssr mailto', async () => {
+  //   await Promise.all([
+  //     page.goto('http://localhost:6969/routes-and-params/hrefs?mailto=1'),
+  //     page.waitForNavigation(),
+  //   ]);
+  //   const url = await page.url();
+  //   expect(url).toEqual('https://nullstack.app/');
+  // });
+  
+  test('ssr relative', async () => {
+    await Promise.all([
+      page.goto('http://localhost:6969/routes-and-params/hrefs?relative=1'),
+      page.waitForNavigation(),
+    ]);
+    const url = await page.url();
+    expect(url).toEqual('http://localhost:6969/routes-and-params/relative');
+  });
+  
+  test('ssr relativeComposed', async () => {
+    await Promise.all([
+      page.goto('http://localhost:6969/routes-and-params/hrefs?relativeComposed=1'),
+      page.waitForNavigation(),
+    ]);
+    const url = await page.url();
+    expect(url).toEqual('http://localhost:6969/routes-and-params/relative/6969');
+  });
+  
+  test('ssr root', async () => {
+    await Promise.all([
+      page.goto('http://localhost:6969/routes-and-params/hrefs?root=1'),
+      page.waitForNavigation(),
+    ]);
+    const url = await page.url();
+    expect(url).toEqual('http://localhost:6969/root/6969');
   });
 
 });

--- a/tests/src/RoutesAndParams.test.js
+++ b/tests/src/RoutesAndParams.test.js
@@ -370,7 +370,7 @@ describe('RoutesAndParams /routes-and-params/hrefs spa', () => {
 });
 
 
-describe('ssr RoutesAndParams /routes-and-params/hrefs', () => {
+describe('RoutesAndParams /routes-and-params/hrefs ssr', () => {
 
   test('ssr parent', async () => {
     await Promise.all([

--- a/tests/src/RoutesAndParams.test.js
+++ b/tests/src/RoutesAndParams.test.js
@@ -268,7 +268,7 @@ describe('RoutesAndParams /routes-and-params/inner-html', () => {
 
 });
 
-describe('RoutesAndParams /routes-and-params/hrefs', () => {
+describe('RoutesAndParams /routes-and-params/hrefs spa', () => {
 
   beforeEach(async () => {
     await page.goto('http://localhost:6969/routes-and-params/hrefs');

--- a/tests/src/RoutesAndParams.test.js
+++ b/tests/src/RoutesAndParams.test.js
@@ -2,7 +2,6 @@ beforeAll(async () => {
   await page.on('dialog', async dialog => {
     await dialog.dismiss();
   })
-  // page.on('console', (msg) => console.log('[LOG]', msg.text()))
 });
 
 describe('RoutesAndParams /routes-and-params', () => {


### PR DESCRIPTION
# Changes

- test package versions
- router links

# New feature

```tsx
      <>
        <a href="https://nullstack.app/"> Nullstack HTTPS</a>
        <a href="http://nullstack.app/"> Nullstack HTTP</a>
        <a href="//nullstack.app/"> Nullstack SAME</a>
        <a href="ftp://nullstack.app/" data-ftp-clicked={this.clickedFtp} onclick={{ clickedFtp: true }}> Nullstack FTP</a>
        <a href="tel:1555696969" data-tel-clicked={this.clickedTel} onclick={{ clickedTel: true }}> Nullstack TEL</a>
        <a href="mailto:contact@nullstack.app" data-mailto-clicked={this.clickedMailTo} onclick={{ clickedMailTo: true }}> Nullstack MAILTO</a>
        <a href="relative"> Nullstack RELATIVE</a>
        <a href="relative/6969"> Nullstack RELATIVE TWO</a>
        <a href="/root/6969"> Nullstack ROOT</a>
        <a href="./current"> Nullstack CURRENT DIR</a>
        <a href="../parent"> Nullstack PARENT DIR</a>
      </>
```