### PR TITLE
Fix bindable

### DIFF
--- a/plugins/bindable.js
+++ b/plugins/bindable.js
@@ -6,7 +6,7 @@ function match(node) {
 
 function transform({ node, environment }) {
   if (!match(node)) return;
-  const object = node.attributes.bind.object;
+  const object = node.attributes.bind.object ?? {};
   const property = node.attributes.bind.property;
   if (node.type === 'textarea') {
     node.children = [object[property]];


### PR DESCRIPTION
Fix bindable when object can be possible undefined, for instance: `bind={user.profile?.age}`. Turns the responsibility to the user and become easier to identify the error.