### PR TITLE
the "source" property should be added for elements that contains the "bind" property

### DIFF
--- a/loaders/add-source-to-node.js
+++ b/loaders/add-source-to-node.js
@@ -1,7 +1,7 @@
 module.exports = function (source) {
   let tags = source.split('<');
   return tags.map((tag) => {
-    match = tag.match(/\ on([a-z]*?)\=\{(.*?)\}/);
+    match = tag.match(/bind\=\{(.*?)\}/);
     if (match && tag.indexOf('source={') === -1) {
       return tag.substring(0, match.index) + ' source={this}' + tag.substring(match.index);
     }


### PR DESCRIPTION
In the current implementation, the `source` is only being added if the element contains a property starting with "on" (like, `onchange`, `onsomething`, etc.)