### PR TITLE
Feat: allow abort server requests

### DIFF
--- a/client/invoke.js
+++ b/client/invoke.js
@@ -4,7 +4,7 @@ import page from './page';
 import worker from './worker';
 
 export default function invoke(name, hash) {
-  return async function _invoke(params = {}) {
+  return async function _invoke(params = {}, fetchOptions = {}) {
     let payload;
     worker.fetching = true;
     if (Object.isFrozen(worker.queues[name])) {
@@ -22,7 +22,8 @@ export default function invoke(name, hash) {
       credentials: 'same-origin',
       redirect: 'follow',
       referrerPolicy: 'no-referrer',
-    }
+      ...fetchOptions,
+    };
     if (/get[A-Z]([*]*)/.test(name)) {
       options.method = 'GET';
       url += `?payload=${encodeURIComponent(body)}`;
@@ -54,5 +55,5 @@ export default function invoke(name, hash) {
     }
     worker.fetching = !!Object.keys(worker.queues).length;
     return payload;
-  }
+  };
 }


### PR DESCRIPTION
Allow abort server requests using the [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) class

Example:

```jsx
import './Home.css';

import Nullstack from 'nullstack';

const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));

export default class Home extends Nullstack {
  static async increment() {
    await sleep(5000);
    return true;
  }

  async handleClick() {
    const controller = new AbortController();
    setTimeout(() => {
      controller.abort();
      console.log('Aborted');
    }, 2000);
    const result = await Home.increment({}, { signal: controller.signal });
    console.log({ result });
  }

  render() {
    return (
      <div>
        <button onclick={this.handleClick}>Submit</button>
      </div>
    );
  }
}
```