### PR TITLE
Fix: Warn about incorrect file inside public folder

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -219,13 +219,12 @@ function server(env, argv) {
   const icons = {}
   const publicFiles = readdirSync(path.join(dir, 'public'))
   const babel = argv.loader === 'babel'
+  const iconFileRegex = /icon-(\d+)x\1\.[a-zA-Z]+/;
   for (const file of publicFiles) {
-    for (const file of publicFiles) {
       if (iconFileRegex.test(file)) {
         const size = file.split('x')[1].split('.')[0];
         icons[size] = `/${file}`;
       }
-    }
   }
   const isDev = argv.environment === 'development'
   const folder = isDev ? '.development' : '.production'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -219,11 +219,11 @@ function server(env, argv) {
   const icons = {}
   const publicFiles = readdirSync(path.join(dir, 'public'))
   const babel = argv.loader === 'babel'
-  const iconFileRegex = /icon-(\d+)x\1\.[a-zA-Z]+/;
+  const iconFileRegex = /icon-(\d+)x\1\.[a-zA-Z]+/
   for (const file of publicFiles) {
     if (iconFileRegex.test(file)) {
-      const size = file.split('x')[1].split('.')[0];
-      icons[size] = `/${file}`;
+      const size = file.split('x')[1].split('.')[0]
+      icons[size] = `/${file}`
     }
   }
   const isDev = argv.environment === 'development'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -220,12 +220,10 @@ function server(env, argv) {
   const publicFiles = readdirSync(path.join(dir, 'public'))
   const babel = argv.loader === 'babel'
   for (const file of publicFiles) {
-    if (file.startsWith('icon-')) {
-      try {
-        const size = file.split('x')[1].split('.')[0]
-        icons[size] = `/${file}`
-      } catch (error) {
-        console.warn(` ⚠️ You have an incorrectly named icon file inside your 'public' folder: ${file}`);
+    for (const file of publicFiles) {
+      if (iconFileRegex.test(file)) {
+        const size = file.split('x')[1].split('.')[0];
+        icons[size] = `/${file}`;
       }
     }
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -221,10 +221,10 @@ function server(env, argv) {
   const babel = argv.loader === 'babel'
   const iconFileRegex = /icon-(\d+)x\1\.[a-zA-Z]+/;
   for (const file of publicFiles) {
-      if (iconFileRegex.test(file)) {
-        const size = file.split('x')[1].split('.')[0];
-        icons[size] = `/${file}`;
-      }
+    if (iconFileRegex.test(file)) {
+      const size = file.split('x')[1].split('.')[0];
+      icons[size] = `/${file}`;
+    }
   }
   const isDev = argv.environment === 'development'
   const folder = isDev ? '.development' : '.production'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -221,8 +221,12 @@ function server(env, argv) {
   const babel = argv.loader === 'babel'
   for (const file of publicFiles) {
     if (file.startsWith('icon-')) {
-      const size = file.split('x')[1].split('.')[0]
-      icons[size] = `/${file}`
+      try {
+        const size = file.split('x')[1].split('.')[0]
+        icons[size] = `/${file}`
+      } catch (error) {
+        console.warn(` ⚠️ You have an incorrectly named icon file inside your 'public' folder: ${file}`);
+      }
     }
   }
   const isDev = argv.environment === 'development'


### PR DESCRIPTION
The problem:

<img width="514" alt="image" src="https://user-images.githubusercontent.com/39849232/208582956-19ae65c7-d75a-421f-9d30-26483fcd312c.png">

Having a file inside public folder named icon-x.png or icon-.png will throw an error due to an uncaught exception while splitting the file name.

The solution: 

Add a warning message about the file, without actually preventing the execution if that's intended by the user of Nullstack.