### PR TITLE
Enable source map on minify

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,6 +37,7 @@ function terserMinimizer(file, _sourceMap) {
   return require('@swc/core').minify(file, {
     keepClassnames: true,
     keepFnames: true,
+    sourceMap: true,
   })
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -229,7 +229,7 @@ function server(env, argv) {
   }
   const isDev = argv.environment === 'development'
   const folder = isDev ? '.development' : '.production'
-  const devtool = isDev ? 'inline-cheap-module-source-map' : false
+  const devtool = isDev ? 'inline-cheap-module-source-map' : 'source-map'
   const minimize = !isDev
   const plugins = []
   if (isDev) {
@@ -359,7 +359,7 @@ function client(env, argv) {
   const entryExtension = existsSync(path.join(dir, 'client.ts')) ? 'ts' : 'js'
   const isDev = argv.environment === 'development'
   const folder = isDev ? '.development' : '.production'
-  const devtool = isDev ? 'inline-cheap-module-source-map' : false
+  const devtool = isDev ? 'inline-cheap-module-source-map' : 'source-map'
   const minimize = !isDev
   const babel = argv.loader === 'babel'
   const plugins = [


### PR DESCRIPTION
Enable source map generation on the build.

If `devtool: 'source-map'` configuration is provided, the build will contain source maps files.

ref.: https://swc.rs/docs/usage/core#minify
