### PR TITLE
🐛 fix: [even-more-unstable-hot] error thrown when using exposed server function with HTTP POST

### DIFF
--- a/server/exposeServerFunctions.js
+++ b/server/exposeServerFunctions.js
@@ -23,7 +23,8 @@ export default function exposeServerFunctions(server) {
             params[key] = extractParamValue(request.query[key])
           }
           if (request.method !== 'GET') {
-            Object.assign(params, deserialize(request.body))
+            const payload = typeof request.body === 'object' ? JSON.stringify(request.body) : request.body
+            Object.assign(params, deserialize(payload))
           }
           try {
             const subcontext = generateContext({ request, response, ...params })

--- a/tests/server.js
+++ b/tests/server.js
@@ -1,6 +1,7 @@
 import Nullstack from 'nullstack'
 
 import cors from 'cors'
+import express from 'express'
 
 import Application from './src/Application'
 import CatchError from './src/CatchError'
@@ -25,6 +26,7 @@ context.server.use(
     optionsSuccessStatus: 200,
   }),
 )
+context.server.use(express.json())
 
 context.worker.staleWhileRevalidate = [/[0-9]/]
 context.worker.cacheFirst = [/[0-9]/]

--- a/tests/src/ExposedServerFunctions.jsx
+++ b/tests/src/ExposedServerFunctions.jsx
@@ -1,14 +1,19 @@
 import Nullstack from 'nullstack'
 
-async function api(method) {
-  const body = {
+async function api(method, contentType = 'text/plain') {
+  const payload = {
     number: 69,
     date: new Date(),
     string: 'nullstack',
   }
   const response = await fetch(`/data/${method}/param?query=query&truthy=true&falsy=false`, {
     method: method.toUpperCase(),
-    body: method === 'get' ? undefined : JSON.stringify(body),
+    ...(method !== 'get' && {
+      headers: {
+        'Content-Type': contentType,
+      },
+      body: JSON.stringify(payload),
+    }),
   })
   const data = await response.json()
   return data.status
@@ -40,20 +45,28 @@ class ExposedServerFunctions extends Nullstack {
     this.chainableRegularFunction = await chainable('regular')
     this.all = await api('get')
     this.get = await api('get')
-    this.post = await api('post')
-    this.put = await api('put')
-    this.patch = await api('patch')
-    this.delete = await api('delete')
+    this.postTextPayload = await api('post')
+    this.postJsonPayload = await api('post', 'application/json')
+    this.putTextPayload = await api('put')
+    this.putJsonPayload = await api('put', 'application/json')
+    this.patchTextPayload = await api('patch')
+    this.patchJsonPayload = await api('patch', 'application/json')
+    this.deleteTextPayload = await api('delete')
+    this.deleteJsonPayload = await api('delete', 'application/json')
   }
 
   render() {
     return (
       <div
         data-get={this.get}
-        data-post={this.post}
-        data-put={this.put}
-        data-patch={this.patch}
-        data-delete={this.delete}
+        data-post={this.postTextPayload}
+        data-post-json={this.postJsonPayload}
+        data-put={this.putTextPayload}
+        data-put-json={this.putJsonPayload}
+        data-patch={this.patchTextPayload}
+        data-patch-json={this.patchJsonPayload}
+        data-delete={this.deleteTextPayload}
+        data-delete-json={this.deleteJsonPayload}
         data-all={this.all}
         data-chainable-server-function={this.chainableServerFunction}
         data-chainable-regular-function={this.chainableRegularFunction}

--- a/tests/src/ExposedServerFunctions.test.js
+++ b/tests/src/ExposedServerFunctions.test.js
@@ -21,27 +21,51 @@ describe('ExposedServerFunctions', () => {
     expect(element).toBeTruthy()
   })
 
-  test('server functions can be exposed to POST and serialize params and query and body', async () => {
+  test('server functions can be exposed to POST and serialize params and query and body as text', async () => {
     await page.waitForSelector('[data-post]')
     const element = await page.$('[data-post]')
     expect(element).toBeTruthy()
   })
 
-  test('server functions can be exposed to PUT and serialize params and query and body', async () => {
+  test('server functions can be exposed to POST and serialize params and query and body as json', async () => {
+    await page.waitForSelector('[data-post-json]')
+    const element = await page.$('[data-post-json]')
+    expect(element).toBeTruthy()
+  })
+
+  test('server functions can be exposed to PUT and serialize params and query and body as text', async () => {
     await page.waitForSelector('[data-put]')
     const element = await page.$('[data-put]')
     expect(element).toBeTruthy()
   })
 
-  test('server functions can be exposed to PATCH and serialize params and query and body', async () => {
+  test('server functions can be exposed to PUT and serialize params and query and body as json', async () => {
+    await page.waitForSelector('[data-put-json]')
+    const element = await page.$('[data-put-json]')
+    expect(element).toBeTruthy()
+  })
+
+  test('server functions can be exposed to PATCH and serialize params and query and body as text', async () => {
     await page.waitForSelector('[data-patch]')
     const element = await page.$('[data-patch]')
     expect(element).toBeTruthy()
   })
 
-  test('server functions can be exposed to DELETE and serialize params and query and body', async () => {
+  test('server functions can be exposed to PATCH and serialize params and query and body as json', async () => {
+    await page.waitForSelector('[data-patch-json]')
+    const element = await page.$('[data-patch-json]')
+    expect(element).toBeTruthy()
+  })
+
+  test('server functions can be exposed to DELETE and serialize params and query and body as text', async () => {
     await page.waitForSelector('[data-delete]')
     const element = await page.$('[data-delete]')
+    expect(element).toBeTruthy()
+  })
+
+  test('server functions can be exposed to DELETE and serialize params and query and body as json', async () => {
+    await page.waitForSelector('[data-delete-json]')
+    const element = await page.$('[data-delete-json]')
     expect(element).toBeTruthy()
   })
 


### PR DESCRIPTION
This PR has the solution for the server function feature that was reported as an issue (#332).

🔥 Loom video with the fix [footage in action](https://www.loom.com/share/52dfdeaa81b541c7af81438a817d4225)!