### PR TITLE
Switch to pnpm at `pr-tests` CI

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -21,13 +21,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 7
       # cache the dependencies from any node_modules directory
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
           path: |
             **/node_modules
-            **/package-lock.json
+            **/pnpm-lock.yaml
           key: node_modules-${{ matrix.node-version }}-${{ hashFiles('**/package.json') }}
 
       - name: Use Node.js ${{ matrix.node-version }}
@@ -37,15 +40,15 @@ jobs:
 
       - name: Install and link main deps
         run: |
-          npm install
-          npm link
+          pnpm install
+          pnpm link --global
 
       - name: Install deps at tests folder
         working-directory: ./tests
         run: |
-          npm link nullstack
-          npm install
+          pnpm link nullstack --global
+          pnpm install
 
       - name: Run tests
         working-directory: ./tests
-        run: npm test
+        run: pnpm test


### PR DESCRIPTION
When checking if a PR were buggy or was a timeout error in CI I discovered the stressful current wait for the CI itself to run.

[This GitHub Action](https://github.com/nullstack/nullstack/actions/runs/4994826117/jobs/8945904659) took 16min to run. Even forgot about that in such a time.
Then I was looking around for the reason and found a slow `npm` resolving (e.g. SWC versions), auditing, installing and then linking deps.

Started to experiment using `pnpm` there (like in my local environment), it's defaults behaviors priorizes doing everything together and excludes auditing step. [This Action run](https://github.com/GuiDevloper/nullstack/actions/runs/5013168914/jobs/8986286216) shows it working with cache.

| Manager | No Cache    | Cached |
|---------|-------------|--------|
| npm     | Up to 20min | 3min   |
| pnpm    | Up to 5min  | 2min   |

> No behavior changed and it comes testing for conflicts with `pnpm` like [this](https://github.com/nullstack/nullstack/pull/344) 😁 

## How to use

- Merge in master/next
- Make a PR against that branch
- Re-run the job or add commit to see cache in action

### Notes for the future

- The minimum required Node.js version noted at [docs](https://nullstack.app/getting-started) should really be changed from v12 to the real v14
- `pnpm` version should be 7 for Node14
- As warned at every Action run, `Node.js 12 actions are deprecated`. As detailed [here](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) in summer 2023 GitHub will switch straight to Node16, then we'll need to update for Actions v3 and [`lironavon/docker-puppeteer-container:16`](https://github.com/liron-navon/docker-puppeteer-container#use-with-github-actions)