### PR TITLE
chore/typescript improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "css-loader": "6.7.3",
     "css-minimizer-webpack-plugin": "^4.2.2",
     "dotenv": "16.0.3",
-    "eslint-plugin-nullstack": "0.0.12",
+    "eslint-plugin-nullstack": "0.0.26",
     "express": "4.18.2",
     "fs-extra": "11.1.0",
     "lightningcss": "^1.19.0",

--- a/types/ClientContext.d.ts
+++ b/types/ClientContext.d.ts
@@ -1,5 +1,5 @@
 import { NullstackEnvironment } from './Environment'
-import { NullstackNode } from './JSX'
+import { NullstackFragment } from './JSX'
 import { NullstackPage } from './Page'
 import { NullstackParams } from './Params'
 import { NullstackProject } from './Project'
@@ -98,7 +98,7 @@ export type NullstackClientContext<TProps = unknown> = TProps & {
    *
    * @see https://nullstack.app/renderable-components#components-with-children
    */
-  children: NullstackNode
+  children: NullstackFragment
 
   /**
    * Bind object.

--- a/types/JSX.d.ts
+++ b/types/JSX.d.ts
@@ -577,10 +577,14 @@ type AriaRole =
   | 'treeitem'
   | (string & {})
 
+type Falsy = false | 0 | '' | null | undefined
+type CssClass = string | Falsy | Array<string | Falsy>
+type CssStyle = string | Falsy | Array<string | Falsy>
+
 export interface HTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
   // Standard HTML Attributes
   accesskey?: string
-  class?: string | string[]
+  class?: CssClass
   contenteditable?: Booleanish | 'inherit'
   contextmenu?: string
   dir?: string
@@ -591,7 +595,7 @@ export interface HTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
   placeholder?: string
   slot?: string
   spellcheck?: Booleanish
-  style?: string
+  style?: CssStyle
   tabindex?: number | string
   title?: string
   translate?: 'yes' | 'no'
@@ -1188,7 +1192,7 @@ export interface VideoHTMLAttributes<T> extends MediaHTMLAttributes<T> {
 //   - union of string literals
 export interface SVGAttributes<T> extends AriaAttributes, DOMAttributes<T> {
   // Attributes which also defined in HTMLAttributes
-  class?: string | string[]
+  class?: CssClass
   color?: string
   height?: number | string
   id?: string
@@ -1198,7 +1202,7 @@ export interface SVGAttributes<T> extends AriaAttributes, DOMAttributes<T> {
   method?: string
   min?: number | string
   name?: string
-  style?: string
+  style?: CssStyle
   target?: string
   type?: string
   width?: number | string
@@ -1426,5 +1430,9 @@ declare global {
     }
 
     interface IntrinsicElements extends ExoticElements, AllElements {}
+
+    interface ElementChildrenAttribute {
+      children: NullstackNode
+    }
   }
 }


### PR DESCRIPTION
1. The `children` property is always and `array` inside the component.
The `children` property type should be `NullstackFragment` instead of `NullstackNode`.

```tsx
class Button extends Nullstack {

  render({ children }: NullstackClientContext) {
    const hasChildren = children.filter(Boolean).length > 0 // <-- children is always an array at this point

    return <button>{hasChildren ? children : 'Default Text'}</button>
  }

}
```

2. The current Typescript types don't support adding `children` as a required property.

```tsx
interface ButtonWithChildrenProps {
  children: JSX.Element // <-- this component must have children
}

class ButtonWithChildren extends Nullstack<ButtonWithChildrenProps> {

  render({ children }: NullstackClientContext) {
    return <button>{children}</button>
  }

}
```

```jsx
<ButtonWithChildren>ButtonWithChildren</ButtonWithChildren> // <-- ERROR here...
```

3. The way of passing values to the `class` and `style` properties mentioned below will fail in `strict mode`.
It should allow `falsy` values or `strings` instead.

```tsx
class ComponentWithStyles extends Nullstack {

  testVariable = false

  render() {
    return [
      <button class={this.testVariable && 'class-a'}>Button A</button>,
      <button class={[this.testVariable && 'class-a']}>Button B</button>,
      <button style={this.testVariable && 'style-a'}>Button C</button>,
      <button style={[this.testVariable && 'style-a']}>Button D</button>,
    ]
  }

}
```

4. Upgrade the `eslint-plugin-nullstack` version