### PR TITLE
:wrench: force unregister of service worker on dev

### DIFF
--- a/server/worker.js
+++ b/server/worker.js
@@ -21,7 +21,7 @@ import settings from './settings'
 
 const worker = {}
 
-worker.enabled = environment.production
+worker.enabled = true
 worker.fetching = false
 worker.preload = []
 worker.staleWhileRevalidate = []

--- a/workers/activate.js
+++ b/workers/activate.js
@@ -4,7 +4,7 @@ function activate(event) {
       const cacheNames = await caches.keys()
       const cachesToDelete = cacheNames.filter((cacheName) => cacheName !== self.context.environment.key)
       await Promise.all(cachesToDelete.map((cacheName) => caches.delete(cacheName)))
-      if (self.registration.navigationPreload) {
+      if ('navigationPreload' in self.registration) {
         await self.registration.navigationPreload.enable()
       }
       self.clients.claim()


### PR DESCRIPTION
# How to test

- [ ] replace nullstack version in package.json with "github:nullstack/nullstack#force-worker-unregister"
- [ ] force deps cleanup and reinstall the deps `rm -rf .development && package-lock.json && yarn.lock && npm install`
- [ ] build in prod mode `npm run build`, open in browser, play around with it make sure it still works
- [ ] run dev server in the same port, open in browser, make some code changes, and make sure hot reload is still working