### PR TITLE
:bug: bug: change automatic scroll behavior when client changes route

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -71,7 +71,7 @@ class Router {
     }
     const absoluteUrl = new URL(target, document.baseURI)
     await this._update(absoluteUrl.pathname + absoluteUrl.search + absoluteUrl.hash, true)
-    window.scroll(0, 0)
+    window.scroll({ top: 0, left: 0, behavior: 'instant' })
   }
 
   get url() {


### PR DESCRIPTION
Small PR to fix route changing scroll behavior inheritance.
E.g: Before this PR, an website with 
```css
html {
  scroll-behavior: smooth;
}
```
was smoothly scroll to the top as the route changed. now it instantly scrolls to the top