### PR TITLE
Sync `ref` types in JSX & Context

### DIFF
--- a/types/ClientContext.d.ts
+++ b/types/ClientContext.d.ts
@@ -11,7 +11,7 @@ import { NullstackWorker } from './Worker'
 /**
  * @see https://nullstack.app/context
  */
-interface BaseNullstackClientContext {
+interface BaseNullstackClientContext<TProps = unknown> {
   /**
    * Callback function that bootstrap the context for the application.
    */
@@ -120,15 +120,17 @@ interface BaseNullstackClientContext {
    *
    * @see https://nullstack.app/refs#complex-refable-components
    */
-  ref?: { property?: string | number; object?: any } | ((context: NullstackClientContext) => void)
+  ref?: TProps extends { ref: any } ? TProps['ref'] : {
+    object: any
+    property: string | number
+  }
 
   /**
    * Ref element.
    *
    * @see https://nullstack.app/refs#complex-refable-components
    */
-
   element?: HTMLElement
 }
 
-export type NullstackClientContext<TProps = unknown> = BaseNullstackClientContext & TProps
+export type NullstackClientContext<TProps = unknown> = BaseNullstackClientContext<TProps> & TProps

--- a/types/JSX.d.ts
+++ b/types/JSX.d.ts
@@ -44,12 +44,12 @@ type Booleanish = boolean | 'true' | 'false'
 // Nullstack Elements
 // ----------------------------------------------------------------------
 
-export interface Attributes<HTMLElementType> {
+export interface Attributes<HTMLElementType = unknown> {
   html?: string
   source?: object
   bind?: any
   debounce?: number
-  ref?: HTMLElementType | ((context?: Partial<NullstackClientContext>) => void)
+  ref?: HTMLElementType | ((context?: Partial<NullstackClientContext>) => void) | NullstackClientContext['ref']
   'data-'?: any
   children?: NullstackNode
   route?: string
@@ -57,9 +57,9 @@ export interface Attributes<HTMLElementType> {
   [key: string]: any
 }
 
-export interface NullstackAttributes<T> extends Attributes<T> {}
+export interface NullstackAttributes extends Attributes {}
 
-export interface ClassAttributes<T> extends Attributes<T> {
+export interface ClassAttributes<T = unknown> extends Attributes<T> {
   key?: string
 }
 
@@ -1233,18 +1233,18 @@ export interface SVGAttributes<T> extends AriaAttributes, DOMAttributes<T> {
   y?: number | string
 }
 
-export type ElementTagHTMLAttributes = AllHTMLAttributes<'div'> & {
+export type ElementTagHTMLAttributes = AllHTMLAttributes<HTMLDivElement> & {
   tag?: string
 }
 
-type ExoticElements = Record<string, DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>>
+type ExoticElements = Record<string, DetailedHTMLProps<HTMLAttributes<HTMLElement> | SVGProps<any> | ElementTagHTMLAttributes, HTMLElement>>
 
 declare global {
   namespace JSX {
     type Element = NullstackNode
 
-    type IntrinsicAttributes = NullstackAttributes<unknown>
-    type IntrinsicClassAttributes = ClassAttributes<unknown>
+    type IntrinsicAttributes = NullstackAttributes
+    type IntrinsicClassAttributes = ClassAttributes
 
     interface AllElements {
       // HTML


### PR DESCRIPTION
Highlights:
- The `ref` injected in [ClientContext](https://github.com/nullstack/nullstack/blob/355f6ca861138cf517e03dcf01344168bcd951a8/types/ClientContext.d.ts#L123) will always be a `{object: ..., property: ...}` (except when typed/passed as prop, e.g. `NullstackClientContext<{ ref: string }>`)

Here a extensive/ostensive list of possible cases working all together after this change and https://github.com/nullstack/nullstack/pull/360:

```tsx
import Nullstack, { NullstackClientContext } from 'nullstack'
const PLACEHOLDER_AUDIO =
  'http://commondatastorage.googleapis.com/codeskulptor-assets/Collision8-Bit.ogg'

class ChildComplexRef extends Nullstack {

  element: HTMLAudioElement = null
  hydrate({ ref }: NullstackClientContext) {
    // ref === { object: ..., property: ... }
    ref.object[ref.property] = this.element // sets parent
    this.element.innerHTML = 'a text to parent' // also sets parent
  }

  render() {
    return <audio ref={this.element} src={PLACEHOLDER_AUDIO} />
  }

}

const constComplexRef = {
  object: { fn: null as HTMLAudioElement },
  property: 'fn' as const,
}

class ComplexRef extends Nullstack {

  complexRef: HTMLAudioElement
  playAudioRef() {
    this.complexRef.play() // plays rightly typed
    constComplexRef.object[constComplexRef.property].play() // also plays rightly typed
  }

  render() {
    return (
      <>
        <ChildComplexRef ref={this.complexRef} />
        <ChildComplexRef ref={constComplexRef} />
        <button onclick={this.playAudioRef}>Play Child's Ref</button>
      </>
    )
  }

}

class SimpleRef extends Nullstack {

  simpleAudioRef: HTMLAudioElement
  runsAfterShowing() {
    console.log('audio tag in the house!')
  }

  render({ ref }: NullstackClientContext) {
    return (
      <>
        <audio ref={this.simpleAudioRef} TS="right!" src={PLACEHOLDER_AUDIO} />
        <audio ref={this.runsAfterShowing} TS="right!" />
        <audio ref={ref} TS="right!" />
        <button onclick={() => this.simpleAudioRef.play()}>
          Play this Ref
        </button>
      </>
    )
  }

}

function PropRef({ ref }: Partial<NullstackClientContext<{ ref: string }>>) {
  return ref // ref === string
}

class Refs extends Nullstack {

  render() {
    return (
      <>
        <SimpleRef />
        <ComplexRef />

        <PropRef ref="a random string prop" />
        <PropRef ref={['TS Error: it should be an string, user!']} />
        <PropRef ref={() => 'TS Error: you know what a string prop means?'} />

        {/**
        // Uncomment this to break render
        // because a Proxy Ref function is not (() => void | function() {})
        <audio
          ref={() => {
            console.log("Error in Nullstack, where're you going at though??")
          }}
        />
        **/}
      </>
    )
  }

}

export default Refs
```

Also:
- In the past `NullstackClientContext['ref']` were wrongly typed with `object | function`, but it could be they two at same time, being better typed with Intersection: `object & function`.. but, with this PR this goes to another level and the `function` type always belonged to `Attributes['ref']` as stated by https://github.com/nullstack/nullstack/pull/360 🚀
- In the past I myself typed `ElementTagHTMLAttributes` with `AllHTMLAttributes<'div'>`, but the `Element` argument always needed to be an `HTMLElement`, being the right: `AllHTMLAttributes<HTMLDivElement>`