### PR TITLE
Avoid building twice for tests and skip build cache

### DIFF
--- a/tests/jest-puppeteer.config.js
+++ b/tests/jest-puppeteer.config.js
@@ -3,7 +3,7 @@ const defaultOptions = {
     headless: true,
   },
   server: {
-    command: 'npm run build && node .production/server.js',
+    command: 'node .production/server.js',
     port: 6969,
     launchTimeout: 25000,
   },
@@ -23,7 +23,7 @@ const ciPipelineOptions = {
     ],
   },
   server: {
-    command: 'npm run build && node .production/server.js',
+    command: 'node .production/server.js',
     port: 6969,
     launchTimeout: 25000,
   },

--- a/tests/package.json
+++ b/tests/package.json
@@ -23,8 +23,8 @@
     "terser": "npm:@swc/core"
   },
   "scripts": {
-    "start": "node ../scripts/index.js start --port=6969 --name=test --disk",
-    "build": "node --enable-source-maps ../scripts/index.js  build --name=test",
+    "start": "node ../scripts/index.js start --port=6969 --name=test --disk -sc",
+    "build": "node --enable-source-maps ../scripts/index.js  build --name=test -sc",
     "clear": "rm -rf ../node_modules ../package-lock.json node_modules .development .production package-lock.json",
     "setup": "cd .. && npm install && cd tests && npm install",
     "test": "npm run build && jest --runInBand",


### PR DESCRIPTION
Tests were supposed to naturally test even faster after all

Example PR running it: https://github.com/GuiDevloper/nullstack/pull/16