### PR TITLE
Add specific types to JSX Attributes['bind']

### DIFF
--- a/types/JSX.d.ts
+++ b/types/JSX.d.ts
@@ -47,7 +47,7 @@ type Booleanish = boolean | 'true' | 'false'
 export interface Attributes<HTMLElementType = unknown> {
   html?: string
   source?: object
-  bind?: any
+  bind?: NullstackClientContext['bind'] | string | number | boolean
   debounce?: number
   ref?: HTMLElementType | ((context?: Partial<NullstackClientContext>) => void) | NullstackClientContext['ref']
   'data-'?: any


### PR DESCRIPTION
Following [the feature](https://github.com/nullstack/nullstack/pull/364) of having stricter types to `Attributes['ref']` and `NullstackClientContext['ref']`, here we are again!