### PR TITLE
Add type to inner components

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -100,6 +100,8 @@ export default class Nullstack<TProps = unknown> {
 
   render?(context: NullstackClientContext<TProps>): NullstackNode
 
+  [_property: `render${Capitalize<string>}`]: Nullstack['render']
+
   prerendered: boolean
 
   /**


### PR DESCRIPTION
<details><summary><h3>TL;DR:</h3></summary>
<p>

<img src="https://github.com/nullstack/nullstack/assets/31557312/b482ad03-b552-4975-b494-025ed82d65fd" height="500px"/>

</p>
</details> 

## Details

This PR makes the [inner components](https://nullstack.app/stateful-components#inner-components) to be typed exactly like `Nullstack['render']`, meaning errors will appear when them are typed differently of that (i.e.: what would be undefined nodes).

PS: It was developed together with what would become the savior for inner components types declaration (i.e. `declare function Head(): NullstackNode`). That is more complex and will be presented in another time (probably as a RFC community proposal)