### PR TITLE
Update Webpack version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "swc-loader": "0.2.3",
     "swc-plugin-nullstack": "0.1.3",
     "terser-webpack-plugin": "5.3.6",
-    "webpack": "5.88.1",
+    "webpack": "5.88.2",
     "webpack-hot-middleware": "2.25.4",
     "webpack-dev-middleware": "github:Mortaro/webpack-dev-middleware#fix-write-to-disk-cleanup"
   }


### PR DESCRIPTION
I did both #373 and #378 which updated dependencies and pinned the Webpack version at `"5.88.1"`, fixing the [pnpm resolver](https://pnpm.io/npmrc#resolution-mode) support for both dev/prod dependencies.

But still it showed the below error for npm:

<details><summary>npm + Nullstack(0.20.2) error (Webpack(5.88.1))</summary>
<p>

![npm-webpack-compilatio-error](https://github.com/nullstack/nullstack/assets/31557312/fd2afc6e-de37-4aa9-bd81-da99ba912e21)

</p>
</details> 

We would still need a Webpack version to choose that supported both pnpm/npm and our [custom `webpack-dev-middleware`](https://github.com/Mortaro/webpack-dev-middleware/tree/fix-write-to-disk-cleanup), something simple like if we kept the old syntax `"^5.0.0"`, but supportive and not opening chance for a too old (or too new) version to be surprisingly installed.

Then I realised that the newly `"5.88.2"` was just there waiting to be tested, and *voilà*, it worked with all those requirements in both npm/pnpm and with/without global cache 🚀
