### PR TITLE
Move webpack-dev-middleware from custom to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "terser-webpack-plugin": "5.3.6",
     "webpack": "5.88.1",
     "webpack-hot-middleware": "2.25.4",
-    "webpack-dev-middleware": "github:Mortaro/webpack-dev-middleware#fix-write-to-disk-cleanup"
+    "webpack-dev-middleware": "6.1.1"
   }
 }


### PR DESCRIPTION
Having it as a git dependency meant that at every install would install their devDeps and built on-the-fly (with `prepare` script)

On another way, Yarn deprecated running the `prepare` and something like that was only reimplemented on v2+ (which can be read-on in issues like those: https://github.com/yarnpkg/yarn/issues/7910 and https://github.com/yarnpkg/berry/issues/957)

Thinking on improving support I thought the best would be to build the package on git itself (simulating the npm registry)

In the end we concluded that using the package custom version wasn't being worth it, then here it is, this PR is just to invest on the latest original package version 🚀

- Requires/well tested together of #382
- For historical purposes, check the full changelog on [`webpack-dev-middleware` releases](https://github.com/webpack/webpack-dev-middleware/releases)