### PR TITLE
:sparkles: feat: custom CWD flag to run nullstack commands

### DIFF
--- a/builders/spa.js
+++ b/builders/spa.js
@@ -1,8 +1,8 @@
-module.exports = async function spa({ output, cache, environment }) {
+module.exports = async function spa({ output, cache, environment, cwd }) {
   const folder = output || 'spa'
   process.env.NULLSTACK_ENVIRONMENT_MODE = 'spa'
 
-  const dir = process.cwd()
+  const dir = cwd
   const application = require(`${dir}/.${environment}/server`).default
   const projectName = application.project.name || 'The Nullstack application'
   const { existsSync, mkdirSync, writeFileSync, copySync, removeSync } = require('fs-extra')

--- a/builders/ssg.js
+++ b/builders/ssg.js
@@ -1,8 +1,8 @@
-module.exports = async function ssg({ output, cache, environment }) {
+module.exports = async function ssg({ output, cache, environment, cwd }) {
   const folder = output || 'ssg'
   process.env.NULLSTACK_ENVIRONMENT_MODE = 'ssg'
 
-  const dir = process.cwd()
+  const dir = cwd
   const application = require(`${dir}/.${environment}/server`).default
   const projectName = application.project.name || 'The Nullstack application'
   const { resolve } = require('path')

--- a/builders/ssr.js
+++ b/builders/ssr.js
@@ -1,5 +1,5 @@
-module.exports = async function ssr({ cache }) {
-  const dir = process.cwd()
+module.exports = async function ssr({ cache, cwd }) {
+  const dir = cwd
   const application = require(`${dir}/.production/server`).default
   const projectName = application.project.name || 'The Nullstack application'
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nullstack",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "description": "Feature-Driven Full Stack JavaScript Components",
   "main": "./types/index.d.ts",
   "author": "Mortaro",

--- a/server/exposeServerFunctions.js
+++ b/server/exposeServerFunctions.js
@@ -40,7 +40,7 @@ export default function exposeServerFunctions(server) {
           if (r?.route?.path === args[0]) {
             const exists = r.route.stack.find((l) => l.method === method)
             if (!!exists && !!process.env.__NULLSTACK_FIRST_LOAD_COMPLETE) {
-              const filename = path.join(process.cwd(), 'server.js')
+              const filename = path.join(server.cwd, 'server.js')
               const time = new Date()
               fs.utimesSync(filename, time, time)
             }

--- a/server/hmr.js
+++ b/server/hmr.js
@@ -19,13 +19,13 @@ export default function hmr(server) {
   const progress = logger('client', 'development')
 
   if (module.hot) {
-    const customConfig = path.resolve(process.cwd(), 'webpack.config.js')
+    const customConfig = path.resolve(server.cwd, 'webpack.config.js')
     const webpackConfigs = existsSync(customConfig)
       ? __non_webpack_require__(customConfig)
       : __non_webpack_require__(path.join(__dirname, '..', 'node_modules', 'nullstack', 'webpack.config.js'))
 
     function resolve(pkg) {
-      if (process.cwd().endsWith('/nullstack/tests') || process.cwd().endsWith('\\nullstack\\tests')) {
+      if (server.cwd.endsWith('/nullstack/tests') || server.cwd.endsWith('\\nullstack\\tests')) {
         return path.join(__dirname, '..', '..', 'node_modules', pkg)
       }
       return pkg
@@ -62,7 +62,7 @@ export default function hmr(server) {
       )
       if (disk) {
         const content = await server.prerender('/')
-        const target = `${process.cwd()}/.development/index.html`
+        const target = `${server.cwd}/.development/index.html`
         writeFileSync(target, content)
       }
     })

--- a/server/lazy.js
+++ b/server/lazy.js
@@ -1,13 +1,16 @@
+const path = require('path')
+
 const queue = {}
 
 export default function lazy(hash, importer) {
   queue[hash] = importer
 }
 
-export async function load(hash) {
+export async function load(hash, cwd) {
   const fileHash = module.hot ? hash.split('___')[0] : hash.slice(0, 8)
-  if (!queue[fileHash]) return
-  const importer = queue[fileHash]
+  const file = path.resolve(cwd || '', fileHash)
+  if (!queue[file]) return
+  const importer = queue[file]
   await importer()
-  delete queue[fileHash]
+  delete queue[file]
 }

--- a/server/manifest.js
+++ b/server/manifest.js
@@ -8,7 +8,7 @@ import project from './project'
 
 export default function generateManifest(server) {
   if (files['manifest.webmanifest']) return files['manifest.webmanifest']
-  const file = path.join(process.cwd(), 'public', 'manifest.webmanifest')
+  const file = path.join(server.cwd, 'public', 'manifest.webmanifest')
   if (existsSync(file)) {
     return readFileSync(file, 'utf-8')
   }

--- a/server/registry.js
+++ b/server/registry.js
@@ -4,11 +4,22 @@ import { getCurrentContext } from "./context"
 import Nullstack from '.'
 import { load } from "./lazy"
 
+const getHashPrefix = () => {
+  const cwd = process.env.__NULLSTACK_CLI_CWD
+  if (!cwd) return ''
+
+  const folders = cwd.split('/').filter(dir => dir && dir !== '.')
+
+  return `${folders.join('__')}__`
+}
+
 export function register(klass, functionName) {
+  const prefix = getHashPrefix()
+
   if (functionName) {
-    registry[`${klass.hash}.${functionName}`] = klass[functionName]
+    registry[`${prefix}${klass.hash}.${functionName}`] = klass[functionName]
   } else {
-    registry[klass.hash] = klass
+    registry[`${prefix}${klass.hash}`] = klass
     bindStaticProps(klass)
   }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -20,6 +20,7 @@ import { generateServiceWorker } from './worker'
 import { load } from './lazy'
 
 const server = express()
+server.cwd = path.resolve(__dirname, '..')
 
 server.port = process.env.NULLSTACK_SERVER_PORT || process.env.PORT || 3000
 
@@ -31,7 +32,7 @@ server.use(async (request, response, next) => {
     typeof context.start === 'function' && (await context.start())
     contextStarted = true
   }
-  generateCurrentContext({request, response}, () => {
+  generateCurrentContext({ request, response }, () => {
     next()
   })
 })
@@ -47,7 +48,7 @@ server.start = function () {
   if (serverStarted) return
   serverStarted = true
 
-  server.use(express.static(path.join(process.cwd(), 'public')))
+  server.use(express.static(path.join(server.cwd, 'public')))
 
   server.use(bodyParser.text({ limit: server.maximumPayloadSize }))
 
@@ -113,7 +114,7 @@ server.start = function () {
   server.get(`/service-worker.js`, (request, response) => {
     response.setHeader('Cache-Control', 'max-age=31536000, immutable')
     response.contentType('text/javascript')
-    response.send(generateServiceWorker())
+    response.send(generateServiceWorker(server.cwd))
   })
 
   server.get('/robots.txt', (request, response) => {

--- a/server/worker.js
+++ b/server/worker.js
@@ -48,16 +48,16 @@ function replacer(key, value) {
   return value
 }
 
-export function generateServiceWorker() {
+export function generateServiceWorker(cwd) {
   if (files['service-worker.js']) return files['service-worker.js']
   const sources = []
   const context = { environment, project, settings, worker }
   let original = ''
-  const file = path.join(process.cwd(), 'public', 'service-worker.js')
+  const file = path.join(cwd, 'public', 'service-worker.js')
   if (existsSync(file)) {
     original = readFileSync(file, 'utf-8')
   }
-  const bundleFolder = path.join(process.cwd(), environment.production ? '.production' : '.development')
+  const bundleFolder = path.join(cwd, environment.production ? '.production' : '.development')
   const scripts = readdirSync(bundleFolder)
     .filter((filename) => filename.includes('.client.') && !filename.endsWith('.map'))
     .map((filename) => `'/${filename}'`)

--- a/tests/webpack.config.js
+++ b/tests/webpack.config.js
@@ -7,13 +7,13 @@ const [server, client] = require('../webpack.config')
 function applyAliases(environments) {
   return environments.map((environment) => (...args) => {
     const config = environment(...args)
-    config.resolve.alias._ = path.join(process.cwd(), '..', 'node_modules');
-    config.resolve.alias["terser"] = path.join(process.cwd(), '..', 'node_modules', '@swc/core');
-    config.resolve.alias.webpack = path.join(process.cwd(), '..', 'node_modules', 'webpack');
+    config.resolve.alias._ = path.join(__dirname, '..', 'node_modules');
+    config.resolve.alias["terser"] = path.join(__dirname, '..', 'node_modules', '@swc/core');
+    config.resolve.alias.webpack = path.join(__dirname, '..', 'node_modules', 'webpack');
     if (config.mode === 'production' && config.target === 'web') {
       config.plugins.push(
         new PurgeCSSPlugin({
-          paths: glob.sync(`src/**/*`, { nodir: true }),
+          paths: glob.sync(path.join(__dirname, `/src/**/*`), { nodir: true }),
           content: ['./**/*.njs'],
           safelist: ['script', 'body', 'html', 'style'],
           defaultExtractor: (content) => content.match(/[^<>"'`\s]*[^<>"'`\s:]/g) || [],

--- a/tests/webpack.config.js
+++ b/tests/webpack.config.js
@@ -13,7 +13,7 @@ function applyAliases(environments) {
     if (config.mode === 'production' && config.target === 'web') {
       config.plugins.push(
         new PurgeCSSPlugin({
-          paths: glob.sync(path.join(__dirname, `/src/**/*`), { nodir: true }),
+          paths: glob.sync(path.join(__dirname, `src/**/*`), { nodir: true }),
           content: ['./**/*.njs'],
           safelist: ['script', 'body', 'html', 'style'],
           defaultExtractor: (content) => content.match(/[^<>"'`\s]*[^<>"'`\s:]/g) || [],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,8 +4,8 @@ const path = require('path')
 function getOptions(target, options) {
   const disk = !!options.disk;
   const environment = options.environment
-  const entry = existsSync(path.posix.join(process.cwd(), `${target}.ts`)) ? `./${target}.ts` : `./${target}.js`
-  const projectFolder = process.cwd()
+  const projectFolder = path.resolve(process.cwd(), options.cwd || '')
+  const entry = existsSync(path.posix.resolve(projectFolder, `${target}.ts`)) ? `./${target}.ts` : `./${target}.js`
   const configFolder = __dirname
   const buildFolder = '.' + environment
   const cache = !options.skipCache
@@ -21,13 +21,15 @@ function getOptions(target, options) {
     name,
     trace,
     projectFolder,
-    configFolder
+    configFolder,
+    cwd: options.cwd
   }
 }
 
 function config(platform, argv) {
   const options = getOptions(platform, argv);
   return {
+    context: options.projectFolder,
     mode: require('./webpack/mode')(options),
     infrastructureLogging: require('./webpack/infrastructureLogging')(options),
     entry: require('./webpack/entry')(options),

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -33,6 +33,7 @@ function nodemon(options) {
   const NodemonPlugin = require('nodemon-webpack-plugin')
   const dotenv = options.name ? `.env.${options.name}` : '.env'
   return new NodemonPlugin({
+    cwd: options.cwd,
     ext: '*',
     watch: [dotenv, './server.js'],
     script: './.development/server.js',


### PR DESCRIPTION
Run nullstack commands as if it had been started in another directory using the flag `--cwd` or `-c`.

Useful for big nullstack monorepos and scripts