### PR TITLE
Updating & reenabling auto PR testing

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -26,7 +26,7 @@ jobs:
           version: 7
       # cache the dependencies from any node_modules directory
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             **/node_modules

--- a/tests/src/RoutesAndParams.test.js
+++ b/tests/src/RoutesAndParams.test.js
@@ -256,6 +256,8 @@ describe('RoutesAndParams /routes-and-params/inner-html', () => {
 })
 
 describe('RoutesAndParams /routes-and-params/hrefs spa', () => {
+  jest.retryTimes(3, { logErrorsBeforeRetry: true, retryImmediately: true })
+
   beforeEach(async () => {
     await page.goto('http://localhost:6969/routes-and-params/hrefs')
     await page.waitForSelector(`[data-application-hydrated]`)


### PR DESCRIPTION
Just updated to make it work again and retry tests that always been flaky (occasionally fail because of the CI environment).

### Extras

Also letting here the possibility to change the Node version we test on (and need to be voted/decided which would be best) and/or test in many of them, I successfully tested even those:
```yaml
node-version: [14.x, 16.x, 18.x, 20.x, 22.x, 24.x]
```

PS: the same could someday be done to package managers, e.g: currently we test on pnpm v7 and before the recent versions (which people probably been using more) that are requiring a [`approve-builds`](https://pnpm.io/cli/approve-builds) here, [`--shamefullyHoist`](https://pnpm.io/cli/install#--shamefully-hoist) there, etc